### PR TITLE
Fix the job to call reusable workflow to build the docker image

### DIFF
--- a/.github/workflows/release-rcs.yml
+++ b/.github/workflows/release-rcs.yml
@@ -37,7 +37,7 @@ jobs:
     with:
       release_version_number: ${{ inputs.release_version_number }}
       release_tag_ref: ${{ needs.release_prepare_no_maven.outputs.release_tag_ref }}
-      SERVICE_NAME: securebanking-ui
+      SERVICE_NAME: ui/rcs
       with_maven: false
     secrets:
       GCR_CREDENTIALS_JSON: ${{ secrets.GCR_CREDENTIALS_JSON }}


### PR DESCRIPTION
- Fix 'SERVICE_NAME' when call the reusable workflow to build the docker image

Issue: https://github.com/secureapigateway/secureapigateway/issues/812