### PR TITLE
Fix outputs to be passed to the reusable workflow release draft

### DIFF
--- a/.github/workflows/release-rcs.yml
+++ b/.github/workflows/release-rcs.yml
@@ -86,8 +86,8 @@ jobs:
     uses: SecureApiGateway/secure-api-gateway-parent/.github/workflows/release-publish-draft-and-pr.yml@master
     with:
       release_version_number: ${{ inputs.release_version_number }}
-      release_branch_ref: ${{ needs.release_prepare.outputs.release_branch_ref }}
-      release_tag_ref: ${{ needs.release_prepare.outputs.release_tag_ref }}
+      release_branch_ref: ${{ needs.release_prepare_no_maven.outputs.release_branch_ref }}
+      release_tag_ref: ${{ needs.release_prepare_no_maven.outputs.release_tag_ref }}
       release_notes: ${{ inputs.notes }}
 
 


### PR DESCRIPTION
- Updated release-rcs workflow

Issue: https://github.com/secureapigateway/secureapigateway/issues/812