### PR TITLE
993: Make UI reachable in the cluster

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -89,7 +89,7 @@ jobs:
       - name: 'Deploy Service'
         uses: codefresh-io/codefresh-pipeline-runner@master
         with:
-          args: '-v TAG=${{ env.PR_NUMBER }} -v SERVICE_NAME=remote-consent-ui -v ENVIRONMENT=${{ env.GITHUB_USER }} -v BRANCH=${{ github.head_ref }}'
+          args: '-v TAG=${{ env.PR_NUMBER }} -v ARGO_VALUES_PREFIX=remoteConsentUi -v SERVICE_NAME=remote-consent-ui -v ENVIRONMENT=${{ env.GITHUB_USER }} -v BRANCH=${{ github.head_ref }}'
         env:
           PIPELINE_NAME: 'ForgeCloud/sbat-infra/service-build'
           CF_API_KEY: ${{ secrets.CF_API_KEY }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -79,10 +79,17 @@ jobs:
         run: |
           helm template $HELM_DIRECTORY/$SERVICE_NAME
 
+      - name: Create lowercase Github Username
+        id: toLowerCase
+        run: echo "GITHUB_USER=$(echo ${{github.actor}} | tr '[:upper:]' '[:lower:]')" >> ${GITHUB_ENV}
+      
+      - name: Output GITHUB_USER env
+        run: echo "GITHUB_USER set to ${{ env.GITHUB_USER }}"          
+
       - name: 'Deploy Service'
         uses: codefresh-io/codefresh-pipeline-runner@master
         with:
-          args: '-v TAG=${{ env.PR_NUMBER }} -v SERVICE_NAME=remote-consent-ui -v ENVIRONMENT=${{ github.actor }} -v BRANCH=${{ github.head_ref }}'
+          args: '-v TAG=${{ env.PR_NUMBER }} -v SERVICE_NAME=remote-consent-ui -v ENVIRONMENT=${{ env.GITHUB_USER }} -v BRANCH=${{ github.head_ref }}'
         env:
           PIPELINE_NAME: 'ForgeCloud/sbat-infra/service-build'
           CF_API_KEY: ${{ secrets.CF_API_KEY }}

--- a/_infra/helm/securebanking-ui/Chart.yaml
+++ b/_infra/helm/securebanking-ui/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: remote-consent-service-user-interface
 description: RCS UI Helm chart for Kubernetes
 type: application
-version: 0.9.1
-appVersion: 0.9.1
+version: 1.0.0
+appVersion: 1.0.0

--- a/_infra/helm/securebanking-ui/templates/rcs-deployment.yaml
+++ b/_infra/helm/securebanking-ui/templates/rcs-deployment.yaml
@@ -13,16 +13,16 @@ spec:
     type: RollingUpdate
   selector:
     matchLabels:
-      app: {{ .Chart.Name }}-{{ .Values.rcsUI.subdomain }}
+      app: {{ .Chart.Name }}
   template:
     metadata:
       labels:
-        app: {{ .Chart.Name }}-{{ .Values.rcsUI.subdomain }}
+        app: {{ .Chart.Name }}
         appVersion: {{ .Chart.AppVersion }}
         helmVersion: {{ .Chart.Version }}
     spec:
       containers:
-        - name: {{ .Chart.Name }}-{{ .Values.rcsUI.subdomain }}
+        - name: {{ .Chart.Name }}
           {{- if .Values.rcsUI.deployment.imageOverride.enabled }}
           image: "{{ .Values.rcsUI.deployment.imageOverride.repo }}:{{ .Values.rcsUI.deployment.imageOverride.tag }}"
           {{- else }}

--- a/_infra/helm/securebanking-ui/templates/rcs-svc.yaml
+++ b/_infra/helm/securebanking-ui/templates/rcs-svc.yaml
@@ -1,7 +1,7 @@
 apiVersion: {{ .Values.apiVersion.service }}
 kind: Service
 metadata:
-  name: {{ .Chart.Name }}-{{ .Values.rcsUI.subdomain }}
+  name: {{ .Chart.Name }}
 spec:
   type: ClusterIP
   ports:
@@ -9,4 +9,4 @@ spec:
     targetPort: {{ .Values.rcsUI.deployment.port }}
     protocol: TCP
   selector:
-    app: {{ .Chart.Name }}-{{ .Values.rcsUI.subdomain }}
+    app: {{ .Chart.Name }}

--- a/_infra/helm/securebanking-ui/values.yaml
+++ b/_infra/helm/securebanking-ui/values.yaml
@@ -10,7 +10,6 @@ deployment:
       server: localhost
 
 rcsUI:
-  subdomain: rcs-ui
   deployment:
     port: 80
     replicas: 1


### PR DESCRIPTION
The remote-consent-server-user-interface has a service called remote-consent-service-user-interface-rcs-ui which means IG is failing to call it at http://remote-consent-service-user-interface:8080

Issue: https://github.com/secureapigateway/secureapigateway/issues/933