### PR TITLE
947: display debtor account preselected when is provided and update the decision object

### DIFF
--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent-dev/consent-dev.component.html
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent-dev/consent-dev.component.html
@@ -1,4 +1,18 @@
-<div *ngFor="let mock of mocks">
-  <h1>{{ mock.type }}</h1>
-  <app-consent-dynamic [response]="mock" [loading]="loading" (formSubmit)="onFormSubmit($event)"></app-consent-dynamic>
+<div class="consent-box">
+  <div>
+    <h1>Consents (no debtor Account provided)</h1>
+    <div *ngFor="let mock of mocks">
+      <h2>{{ mock.type }}</h2>
+      <app-consent-dynamic [response]="mock" [loading]="loading"
+                           (formSubmit)="onFormSubmit($event)"></app-consent-dynamic>
+    </div>
+  </div>
+  <div>
+    <h1>Consents (with debtor account provided)</h1>
+    <div *ngFor="let mockDebtorAccount of mocksDebtorAccount">
+      <h2>{{ mockDebtorAccount.type }}</h2>
+      <app-consent-dynamic [response]="mockDebtorAccount" [loading]="loading"
+                           (formSubmit)="onFormSubmit($event)"></app-consent-dynamic>
+    </div>
+  </div>
 </div>

--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent-dev/consent-dev.component.ts
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent-dev/consent-dev.component.ts
@@ -9,6 +9,15 @@ import mock6 from './mocks/international-payment-consent-details';
 import mock7 from './mocks/international-scheduled-payment-consent-details';
 import mock8 from './mocks/international-standing-order-consent-details';
 import mock9 from './mocks/file-payment-consent-details';
+// debtor account mocks
+import mock30 from './mocks/debtorAccountProvided/vrp-payment-consent-details';
+import mock31 from './mocks/debtorAccountProvided/domestic-payment-consent-details';
+import mock32 from './mocks/debtorAccountProvided/domestic-scheduled-payment-response-details';
+import mock33 from './mocks/debtorAccountProvided/domestic-standing-order-response-details';
+import mock34 from './mocks/debtorAccountProvided/international-payment-consent-details';
+import mock35 from './mocks/debtorAccountProvided/international-scheduled-payment-consent-details';
+import mock36 from './mocks/debtorAccountProvided/international-standing-order-consent-details';
+import mock37 from './mocks/debtorAccountProvided/file-payment-consent-details';
 
 import { IConsentEventEmitter } from '../../types/consentItem';
 
@@ -21,6 +30,7 @@ import { IConsentEventEmitter } from '../../types/consentItem';
 export class ConsentDevComponent implements OnInit {
   loading = false;
   mocks: any[] = [mock1, mock2, mock3, mock4, mock5, mock6, mock7, mock8, mock9];
+  mocksDebtorAccount: any[] = [mock30,mock31,mock32,mock33,mock34,mock35,mock36,mock37];
   constructor(private cdr: ChangeDetectorRef) {}
 
   ngOnInit() {}

--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent-dev/mocks/debtorAccountProvided/domestic-payment-consent-details.js
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent-dev/mocks/debtorAccountProvided/domestic-payment-consent-details.js
@@ -1,0 +1,69 @@
+module.exports = {
+  type: "DomesticPaymentsConsentDetails",
+  decisionApiUri: "/rcs/api/consent/decision/",
+  username: "psu4test",
+  userId: "7b78b560-6057-41c5-bf1f-1ed590b1c30b",
+  logo: "https://forgerock.com",
+  clientId: "b437c832-e79c-4479-84b0-56e8ec403232",
+  clientName: "TPP Test application",
+  serviceProviderName: "Forgerock Bank simulation config",
+  initiation: {
+    debtorAccount: {
+      schemeName: "UK.OBIE.SortCodeAccountNumber",
+      identification: "30772183765717",
+      name: "Will Smith account",
+      secondaryIdentification: "66234289"
+    },
+    creditorAccount: {
+      schemeName: "UK.OBIE.SortCodeAccountNumber",
+      identification: "08080021325698",
+      name: "ACME Inc",
+      secondaryIdentification: "0002"
+    }
+  },
+  instructedAmount: {
+    amount: "165.88",
+    currency: "GBP"
+  },
+  accounts: [
+    {
+      id: "cdb062f6-daed-479a-8843-00f842926ef7",
+      userId: "7b78b560-6057-41c5-bf1f-1ed590b1c30b",
+      account: {
+        accountId: "cdb062f6-daed-479a-8843-00f842926ef7",
+        status: "Enabled",
+        statusUpdateDateTime: "2022-04-01T11:35:15.368Z",
+        currency: "GBP",
+        accountType: "Personal",
+        accountSubType: "CurrentAccount",
+        nickname: "UK Bills",
+        openingDate: "2022-03-31T11:35:15.368Z",
+        maturityDate: "2022-04-02T11:35:15.368Z",
+        accounts: [
+          {
+            schemeName: "UK.OBIE.SortCodeAccountNumber",
+            identification: "30772183765717",
+            name: "Will Smith account",
+            secondaryIdentification: "66234289"
+          }
+        ]
+      },
+      latestStatementId: "995af620-0f5c-4071-a7ca-6591038d12c4",
+      created: "2022-04-01T11:35:15.368Z",
+      balances: [
+        {
+          accountId: "cdb062f6-daed-479a-8843-00f842926ef7",
+          creditDebitIndicator: "Debit",
+          type: "InterimAvailable",
+          dateTime: "2022-04-01T11:35:15.373Z",
+          amount: {
+            amount: "1679.63",
+            currency: "GBP"
+          }
+        }
+      ]
+    }
+  ],
+  paymentReference: "FRESCO-101",
+  intentType: "PAYMENT_DOMESTIC_CONSENT"
+}

--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent-dev/mocks/debtorAccountProvided/domestic-scheduled-payment-response-details.js
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent-dev/mocks/debtorAccountProvided/domestic-scheduled-payment-response-details.js
@@ -1,0 +1,70 @@
+module.exports = {
+  type: "DomesticScheduledPaymentConsentDetails",
+  decisionApiUri: "/rcs/api/consent/decision/",
+  username: "psu4test",
+  userId: "737742f2-01e4-4efa-a131-77e6526f98d2",
+  logo: "https://forgerock.com",
+  clientId: "5d649549-bfea-4f23-b071-618fcb74e37f",
+  clientName: "TPP Test application",
+  serviceProviderName: "Forgerock Bank simulation config",
+  initiation: {
+    debtorAccount: {
+      schemeName: "UK.OBIE.SortCodeAccountNumber",
+      identification: "30772183765717",
+      name: "Will Smith account",
+      secondaryIdentification: "66234289"
+    },
+    creditorAccount: {
+      schemeName: "UK.OBIE.SortCodeAccountNumber",
+      identification: "08080021325698",
+      name: "ACME Inc",
+      secondaryIdentification: "0002"
+    }
+  },
+  instructedAmount: {
+    amount: "10.01",
+    currency: "GBP"
+  },
+  accounts: [
+    {
+      id: "cdb062f6-daed-479a-8843-00f842926ef7",
+      userId: "7b78b560-6057-41c5-bf1f-1ed590b1c30b",
+      account: {
+        accountId: "cdb062f6-daed-479a-8843-00f842926ef7",
+        status: "Enabled",
+        statusUpdateDateTime: "2022-04-01T11:35:15.368Z",
+        currency: "GBP",
+        accountType: "Personal",
+        accountSubType: "CurrentAccount",
+        nickname: "UK Bills",
+        openingDate: "2022-03-31T11:35:15.368Z",
+        maturityDate: "2022-04-02T11:35:15.368Z",
+        accounts: [
+          {
+            schemeName: "UK.OBIE.SortCodeAccountNumber",
+            identification: "30772183765717",
+            name: "Will Smith account",
+            secondaryIdentification: "66234289"
+          }
+        ]
+      },
+      latestStatementId: "995af620-0f5c-4071-a7ca-6591038d12c4",
+      created: "2022-04-01T11:35:15.368Z",
+      balances: [
+        {
+          accountId: "cdb062f6-daed-479a-8843-00f842926ef7",
+          creditDebitIndicator: "Debit",
+          type: "InterimAvailable",
+          dateTime: "2022-04-01T11:35:15.373Z",
+          amount: {
+            amount: "1679.63",
+            currency: "GBP"
+          }
+        }
+      ]
+    }
+  ],
+  paymentDate: "2022-06-08T12:16:03.000Z",
+  paymentReference: "FRESCO-037",
+  intentType: "PAYMENT_DOMESTIC_SCHEDULED_CONSENT"
+};

--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent-dev/mocks/debtorAccountProvided/domestic-standing-order-response-details.js
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent-dev/mocks/debtorAccountProvided/domestic-standing-order-response-details.js
@@ -1,0 +1,83 @@
+module.exports = {
+  type: "DomesticStandingOrderConsentDetails",
+  decisionApiUri: "/rcs/api/consent/decision/",
+  username: "psu4test",
+  userId: "42edfd13-a642-47c1-b76c-684efe4e6449",
+  logo: "https://forgerock.com",
+  clientId: "63bce7d3-0c74-4188-9d24-88e3a69d3c80",
+  clientName: "TPP Test application",
+  serviceProviderName: "Forgerock Bank simulation config",
+  initiation: {
+    debtorAccount: {
+      schemeName: "UK.OBIE.SortCodeAccountNumber",
+      identification: "30772183765717",
+      name: "Will Smith account",
+      secondaryIdentification: "66234289"
+    },
+    creditorAccount: {
+      schemeName: "UK.OBIE.SortCodeAccountNumber",
+      identification: "08080021325698",
+      name: "ACME Inc",
+      secondaryIdentification: "0002"
+    }
+  },
+  standingOrder: {
+      type: "FRWriteDomesticStandingOrderDataInitiation",
+      frequency: "Paid on the 25th March, 24th June, 29th September and 25th December.",
+      firstPaymentDateTime: "2022-06-21T06:06:06.000Z",
+      finalPaymentDateTime: "2023-03-20T06:06:06.000Z",
+      firstPaymentAmount: {
+          amount: "165.88",
+          currency: "GBP"
+      },
+      recurringPaymentAmount: {
+          amount: "165.88",
+          currency: "GBP"
+      },
+      finalPaymentAmount: {
+          amount: "165.88",
+          currency: "GBP"
+      }
+  },
+  accounts: [
+    {
+      id: "cdb062f6-daed-479a-8843-00f842926ef7",
+      userId: "7b78b560-6057-41c5-bf1f-1ed590b1c30b",
+      account: {
+        accountId: "cdb062f6-daed-479a-8843-00f842926ef7",
+        status: "Enabled",
+        statusUpdateDateTime: "2022-04-01T11:35:15.368Z",
+        currency: "GBP",
+        accountType: "Personal",
+        accountSubType: "CurrentAccount",
+        nickname: "UK Bills",
+        openingDate: "2022-03-31T11:35:15.368Z",
+        maturityDate: "2022-04-02T11:35:15.368Z",
+        accounts: [
+          {
+            schemeName: "UK.OBIE.SortCodeAccountNumber",
+            identification: "30772183765717",
+            name: "Will Smith account",
+            secondaryIdentification: "66234289"
+          }
+        ]
+      },
+      latestStatementId: "995af620-0f5c-4071-a7ca-6591038d12c4",
+      created: "2022-04-01T11:35:15.368Z",
+      balances: [
+        {
+          accountId: "cdb062f6-daed-479a-8843-00f842926ef7",
+          creditDebitIndicator: "Debit",
+          type: "InterimAvailable",
+          dateTime: "2022-04-01T11:35:15.373Z",
+          amount: {
+            amount: "1679.63",
+            currency: "GBP"
+          }
+        }
+      ]
+    }
+  ],
+  paymentReference: "Reference text",
+  intentType: "PAYMENT_DOMESTIC_STANDING_ORDERS_CONSENT"
+};

--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent-dev/mocks/debtorAccountProvided/file-payment-consent-details.js
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent-dev/mocks/debtorAccountProvided/file-payment-consent-details.js
@@ -1,0 +1,66 @@
+module.exports = {
+  type: "FilePaymentConsentDetails",
+  decisionApiUri: "/rcs/api/consent/decision/",
+  username: "testUserName",
+  userId: "c7303aee-2ff1-44b5-b21f-a7a3aaf39271",
+  logo: "https://www.vhv.rs/dpng/d/455-4556963_warner-bros-logo-warner-brothers-logo-png-transparent.png",
+  clientId: "3bce98ec-755f-42f6-9f82-0a120a6db559",
+  clientName: "TPP Test application",
+  serviceProviderName: "Forgerock Bank simulation config",
+  filePayment: {
+    fileReference: "XmlExample",
+    numberOfTransactions: "3",
+    controlSum: 11500000,
+    requestedExecutionDateTime: "2023-09-27T13:03:06.000Z",
+    debtorAccount: {
+      schemeName: "UK.OBIE.SortCodeAccountNumber",
+      identification: "30772183765717",
+      name: "Will Smith account",
+      secondaryIdentification: "66234289"
+    },
+  },
+  accounts: [
+    {
+      id: "cdb062f6-daed-479a-8843-00f842926ef7",
+      userId: "7b78b560-6057-41c5-bf1f-1ed590b1c30b",
+      account: {
+        accountId: "cdb062f6-daed-479a-8843-00f842926ef7",
+        status: "Enabled",
+        statusUpdateDateTime: "2022-04-01T11:35:15.368Z",
+        currency: "GBP",
+        accountType: "Personal",
+        accountSubType: "CurrentAccount",
+        nickname: "UK Bills",
+        openingDate: "2022-03-31T11:35:15.368Z",
+        maturityDate: "2022-04-02T11:35:15.368Z",
+        accounts: [
+          {
+            schemeName: "UK.OBIE.SortCodeAccountNumber",
+            identification: "30772183765717",
+            name: "Will Smith account",
+            secondaryIdentification: "66234289"
+          }
+        ]
+      },
+      latestStatementId: "995af620-0f5c-4071-a7ca-6591038d12c4",
+      created: "2022-04-01T11:35:15.368Z",
+      balances: [
+        {
+          accountId: "cdb062f6-daed-479a-8843-00f842926ef7",
+          creditDebitIndicator: "Debit",
+          type: "InterimAvailable",
+          dateTime: "2022-04-01T11:35:15.373Z",
+          amount: {
+            amount: "1679.63",
+            currency: "GBP"
+          }
+        }
+      ]
+    }
+  ],
+  charges: {
+    amount: "21.11",
+    currency: "GBP"
+  },
+  intentType: "PAYMENT_FILE_CONSENT"
+};

--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent-dev/mocks/debtorAccountProvided/international-payment-consent-details.js
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent-dev/mocks/debtorAccountProvided/international-payment-consent-details.js
@@ -1,0 +1,80 @@
+module.exports = {
+  type: "InternationalPaymentConsentDetails",
+  decisionApiUri: "/rcs/api/consent/decision/",
+  username: "psu4test",
+  userId: "86228a9d-812d-4a15-a2f7-6a45488e593b",
+  logo: "https://forgerock.com",
+  clientId: "ec0a5142-ea7c-4b82-8ff0-f24e3a526a9c",
+  clientName: "TPP Test application",
+  serviceProviderName: "Forgerock Bank simulation config",
+  initiation: {
+    debtorAccount: {
+      schemeName: "UK.OBIE.SortCodeAccountNumber",
+      identification: "30772183765717",
+      name: "Will Smith account",
+      secondaryIdentification: "66234289"
+    },
+    creditorAccount: {
+      schemeName: "UK.OBIE.SortCodeAccountNumber",
+      identification: "08080021325698",
+      name: "ACME Inc",
+      secondaryIdentification: "0002"
+    }
+  },
+  instructedAmount: {
+    amount: "10.01",
+    currency: "GBP"
+  },
+  exchangeRateInformation: {
+    unitCurrency: "EUR",
+    exchangeRate: 10,
+    rateType: "AGREED",
+    contractIdentification: "/tbill/2018/T102993"
+  },
+  charges: {
+    amount: "1.5",
+    currency: "GBP"
+  },
+  currencyOfTransfer: "EUR",
+  paymentReference: "FRESCO-037",
+  accounts: [
+    {
+      id: "cdb062f6-daed-479a-8843-00f842926ef7",
+      userId: "7b78b560-6057-41c5-bf1f-1ed590b1c30b",
+      account: {
+        accountId: "cdb062f6-daed-479a-8843-00f842926ef7",
+        status: "Enabled",
+        statusUpdateDateTime: "2022-04-01T11:35:15.368Z",
+        currency: "GBP",
+        accountType: "Personal",
+        accountSubType: "CurrentAccount",
+        nickname: "UK Bills",
+        openingDate: "2022-03-31T11:35:15.368Z",
+        maturityDate: "2022-04-02T11:35:15.368Z",
+        accounts: [
+          {
+            schemeName: "UK.OBIE.SortCodeAccountNumber",
+            identification: "30772183765717",
+            name: "Will Smith account",
+            secondaryIdentification: "66234289"
+          }
+        ]
+      },
+      latestStatementId: "995af620-0f5c-4071-a7ca-6591038d12c4",
+      created: "2022-04-01T11:35:15.368Z",
+      balances: [
+        {
+          accountId: "cdb062f6-daed-479a-8843-00f842926ef7",
+          creditDebitIndicator: "Debit",
+          type: "InterimAvailable",
+          dateTime: "2022-04-01T11:35:15.373Z",
+          amount: {
+            amount: "1679.63",
+            currency: "GBP"
+          }
+        }
+      ]
+    }
+  ],
+  intentType: "PAYMENT_INTERNATIONAL_CONSENT"
+}

--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent-dev/mocks/debtorAccountProvided/international-scheduled-payment-consent-details.js
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent-dev/mocks/debtorAccountProvided/international-scheduled-payment-consent-details.js
@@ -1,0 +1,81 @@
+module.exports = {
+  type: "InternationalScheduledPaymentConsentDetails",
+  decisionApiUri: "/rcs/api/consent/decision/",
+  username: "psu4test",
+  userId: "86228a9d-812d-4a15-a2f7-6a45488e593b",
+  logo: "https://forgerock.com",
+  clientId: "ec0a5142-ea7c-4b82-8ff0-f24e3a526a9c",
+  clientName: "TPP Test application",
+  serviceProviderName: "Forgerock Bank simulation config",
+  initiation: {
+    debtorAccount: {
+      schemeName: "UK.OBIE.SortCodeAccountNumber",
+      identification: "30772183765717",
+      name: "Will Smith account",
+      secondaryIdentification: "66234289"
+    },
+    creditorAccount: {
+      schemeName: "UK.OBIE.SortCodeAccountNumber",
+      identification: "08080021325698",
+      name: "ACME Inc",
+      secondaryIdentification: "0002"
+    }
+  },
+  instructedAmount: {
+    amount: "10.01",
+    currency: "GBP"
+  },
+  charges: {
+    amount: "1.5",
+    currency: "GBP"
+  },
+  exchangeRateInformation: {
+    unitCurrency: "EUR",
+    exchangeRate: 10,
+    rateType: "AGREED",
+    contractIdentification: "/tbill/2018/T102993"
+  },
+  paymentDate: "2022-09-21T08:46:53.000Z",
+  currencyOfTransfer: "EUR",
+  paymentReference: "FRESCO-037",
+  accounts: [
+    {
+      id: "cdb062f6-daed-479a-8843-00f842926ef7",
+      userId: "7b78b560-6057-41c5-bf1f-1ed590b1c30b",
+      account: {
+        accountId: "cdb062f6-daed-479a-8843-00f842926ef7",
+        status: "Enabled",
+        statusUpdateDateTime: "2022-04-01T11:35:15.368Z",
+        currency: "GBP",
+        accountType: "Personal",
+        accountSubType: "CurrentAccount",
+        nickname: "UK Bills",
+        openingDate: "2022-03-31T11:35:15.368Z",
+        maturityDate: "2022-04-02T11:35:15.368Z",
+        accounts: [
+          {
+            schemeName: "UK.OBIE.SortCodeAccountNumber",
+            identification: "30772183765717",
+            name: "Will Smith account",
+            secondaryIdentification: "66234289"
+          }
+        ]
+      },
+      latestStatementId: "995af620-0f5c-4071-a7ca-6591038d12c4",
+      created: "2022-04-01T11:35:15.368Z",
+      balances: [
+        {
+          accountId: "cdb062f6-daed-479a-8843-00f842926ef7",
+          creditDebitIndicator: "Debit",
+          type: "InterimAvailable",
+          dateTime: "2022-04-01T11:35:15.373Z",
+          amount: {
+            amount: "1679.63",
+            currency: "GBP"
+          }
+        }
+      ]
+    }
+  ],
+  intentType: "PAYMENT_INTERNATIONAL_SCHEDULED_CONSENT"
+}

--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent-dev/mocks/debtorAccountProvided/international-standing-order-consent-details.js
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent-dev/mocks/debtorAccountProvided/international-standing-order-consent-details.js
@@ -1,0 +1,80 @@
+module.exports = {
+  type: "InternationalStandingOrderConsentDetails",
+  decisionApiUri: "/rcs/api/consent/decision/",
+  username: "psu4test",
+  userId: "24a3b7b8-b477-446b-8bec-69214d8a3582",
+  logo: "https://forgerock.com",
+  clientId: "aecab376-5c1d-4874-8549-475aa0eb68d2",
+  clientName: "TPP Test application",
+  serviceProviderName: "Forgerock Bank simulation config",
+  initiation: {
+    debtorAccount: {
+      schemeName: "UK.OBIE.SortCodeAccountNumber",
+      identification: "30772183765717",
+      name: "Will Smith account",
+      secondaryIdentification: "66234289"
+    },
+    creditorAccount: {
+      schemeName: "UK.OBIE.SortCodeAccountNumber",
+      identification: "08080021325698",
+      name: "ACME Inc",
+      secondaryIdentification: "0002"
+    }
+  },
+  internationalStandingOrder: {
+    type: "FRWriteInternationalStandingOrderDataInitiation",
+    frequency: "Every working day.",
+    firstPaymentDateTime: "2022-09-27T10:03:06.000Z",
+    finalPaymentDateTime: "2022-09-27T10:03:06.000Z",
+    instructedAmount: {
+      amount: "10.01",
+      currency: "GBP"
+    }
+  },
+  accounts: [
+    {
+      id: "cdb062f6-daed-479a-8843-00f842926ef7",
+      userId: "7b78b560-6057-41c5-bf1f-1ed590b1c30b",
+      account: {
+        accountId: "cdb062f6-daed-479a-8843-00f842926ef7",
+        status: "Enabled",
+        statusUpdateDateTime: "2022-04-01T11:35:15.368Z",
+        currency: "GBP",
+        accountType: "Personal",
+        accountSubType: "CurrentAccount",
+        nickname: "UK Bills",
+        openingDate: "2022-03-31T11:35:15.368Z",
+        maturityDate: "2022-04-02T11:35:15.368Z",
+        accounts: [
+          {
+            schemeName: "UK.OBIE.SortCodeAccountNumber",
+            identification: "30772183765717",
+            name: "Will Smith account",
+            secondaryIdentification: "66234289"
+          }
+        ]
+      },
+      latestStatementId: "995af620-0f5c-4071-a7ca-6591038d12c4",
+      created: "2022-04-01T11:35:15.368Z",
+      balances: [
+        {
+          accountId: "cdb062f6-daed-479a-8843-00f842926ef7",
+          creditDebitIndicator: "Debit",
+          type: "InterimAvailable",
+          dateTime: "2022-04-01T11:35:15.373Z",
+          amount: {
+            amount: "1679.63",
+            currency: "GBP"
+          }
+        }
+      ]
+    }
+  ],
+  charges: {
+    amount: "1.5",
+    currency: "GBP"
+  },
+  currencyOfTransfer: "USD",
+  paymentReference: "Ipsum Non Arcu Inc.",
+  intentType: "PAYMENT_INTERNATIONAL_STANDING_ORDERS_CONSENT"
+}

--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent-dev/mocks/debtorAccountProvided/vrp-payment-consent-details.js
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent-dev/mocks/debtorAccountProvided/vrp-payment-consent-details.js
@@ -1,0 +1,87 @@
+module.exports = {
+  type: "DomesticVrpPaymentConsentDetails",
+  decisionApiUri: "/rcs/api/consent/decision/",
+  username: "testUserName",
+  userId: "c7303aee-2ff1-44b5-b21f-a7a3aaf39271",
+  logo: "https://www.vhv.rs/dpng/d/455-4556963_warner-bros-logo-warner-brothers-logo-png-transparent.png",
+  clientId: "8c57af60-39ef-4eec-8309-d17d026843ac",
+  clientName: "TPP Test application",
+  serviceProviderName: "Forgerock Bank simulation config",
+  initiation: {
+    type: "FRWriteDomesticVRPDataInitiation",
+    debtorAccount: {
+      schemeName: "UK.OBIE.SortCodeAccountNumber",
+      identification: "30772183765717",
+      name: "Will Smith account",
+      secondaryIdentification: "66234289"
+    },
+    creditorAccount: {
+      schemeName: "UK.OBIE.SortCodeAccountNumber",
+      identification: "08080021325698",
+      name: "ACME Inc",
+      secondaryIdentification: "0002"
+    }
+  },
+  accounts: [
+    {
+      id: "8614e6bf-2ba3-40eb-9fd4-5a4d77785f50",
+      userId: "3ee885ee-ae0b-45a5-b061-8c19fdaab76f",
+      account: {
+        accountId: "8614e6bf-2ba3-40eb-9fd4-5a4d77785f50",
+        status: "Enabled",
+        statusUpdateDateTime: "2023-01-11T07:00:05.000Z",
+        currency: "GBP",
+        accountType: "Personal",
+        accountSubType: "CurrentAccount",
+        nickname: "UK Bills",
+        openingDate: "2023-01-10T07:00:05.000Z",
+        maturityDate: "2023-01-12T07:00:05.000Z",
+        accounts: [
+          {
+            schemeName: "UK.OBIE.SortCodeAccountNumber",
+            identification: "30772183765717",
+            name: "Will Smith account",
+            secondaryIdentification: "66234289"
+          }
+        ]
+      },
+      latestStatementId: "f9ad6fe2-7a2e-4f44-ad58-d87c4f6e110c",
+      created: "2023-01-11T07:00:05.000Z",
+      balances: [
+        {
+          accountId: "8614e6bf-2ba3-40eb-9fd4-5a4d77785f50",
+          creditDebitIndicator: "Debit",
+          type: "InterimAvailable",
+          dateTime: "2023-01-11T07:00:06.000Z",
+          amount: {
+            amount: "7853.64",
+            currency: "GBP"
+          }
+        }
+      ]
+    }
+  ],
+  controlParameters: {
+    ValidFromDateTime: "2022-11-28T11:35:30.510Z",
+    ValidToDateTime: "2022-11-28T11:35:30.510Z",
+    MaximumIndividualAmount: {
+      Amount: "10.01",
+      Currency: "GBP"
+    },
+    PeriodicLimits: [
+      {
+        PeriodType: "Month",
+        PeriodAlignment: "Calendar",
+        Amount: "10.01",
+        Currency: "GBP"
+      }
+    ],
+    VRPType: [
+      "UK.OBIE.VRPType.Sweeping"
+    ],
+    PSUAuthenticationMethods: [
+      "UK.OBIE.SCANotRequired"
+    ]
+  },
+  intentType: "DOMESTIC_VRP_PAYMENT_CONSENT"
+}

--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/consent.component.spec.ts
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/consent.component.spec.ts
@@ -67,14 +67,14 @@ describe('app:bank ConsentComponent', () => {
     const decisionApiUri = 'https://test.com';
     component.consentRequest = "eyJhbGciOiJIUzI1NiJ9.ewoiY2xpZW50SWQiOiJhMTJjOTA3Ni02MTM2LTQzOTAtOTEwZS02MDNkZjAxN2JmMzIiLCJpc3MiOiJodHRwczovL2lhbS5kZXYuZm9yZ2Vyb2NrLmZpbmFuY2lhbDo0NDMvYW0vb2F1dGgyL3JlYWxtcy9yb290L3JlYWxtcy9hbHBoYSIsImNzcmYiOiJUamdqM0hUelJsMnZuK1RtSWxQaGl6YjlncWRmUjdabjJhL3I1aUgrc3lBPSIsImNsaWVudF9kZXNjcmlwdGlvbiI6IiIsImF1ZCI6ImZvcmdlcm9jay1yY3MiLCJzYXZlX2NvbnNlbnRfZW5hYmxlZCI6dHJ1ZSwiY2xhaW1zIjp7ImlkX3Rva2VuIjp7ImFjciI6eyJ2YWx1ZSI6InVybjpvcGVuYmFua2luZzpwc2QyOnNjYSIsImVzc2VudGlhbCI6dHJ1ZX0sIm9wZW5iYW5raW5nX2ludGVudF9pZCI6eyJ2YWx1ZSI6IkFBQ19kNzk5ZWUyYi00NTZmLTQ1OTAtYTZhYS0xN2IxZWYxYzE3ZDQiLCJlc3NlbnRpYWwiOnRydWV9fSwidXNlcmluZm8iOnsib3BlbmJhbmtpbmdfaW50ZW50X2lkIjp7InZhbHVlIjoiQUFDX2Q3OTllZTJiLTQ1NmYtNDU5MC1hNmFhLTE3YjFlZjFjMTdkNCIsImVzc2VudGlhbCI6dHJ1ZX19fSwic2NvcGVzIjp7ImFjY291bnRzIjoiYWNjb3VudHMiLCJvcGVuaWQiOiJvcGVuaWQiLCJwYXltZW50cyI6InBheW1lbnRzIn0sImV4cCI6MTYxNDk1NDA1NCwiaWF0IjoxNjE0OTUzODc0LCJjbGllbnRfbmFtZSI6ImJkZGRiNDMwLTMxNjAtNGFlYi04NWI5LWRkZWJjYjBiOGJhMiIsImNvbnNlbnRBcHByb3ZhbFJlZGlyZWN0VXJpIjoiaHR0cHM6Ly9pYW0uZGV2LmZvcmdlcm9jay5maW5hbmNpYWw6NDQzL2FtL29hdXRoMi9yZWFsbXMvcm9vdC9yZWFsbXMvYWxwaGE_cmVzcG9uc2VfdHlwZT1jb2RlJTIwaWRfdG9rZW4mY2xpZW50X2lkPWExMmM5MDc2LTYxMzYtNDM5MC05MTBlLTYwM2RmMDE3YmYzMiZyZWRpcmVjdF91cmk9aHR0cHM6Ly9wb3N0bWFuLWVjaG8uY29tL2dldCIsInVzZXJuYW1lIjoiNTlkOGE2M2MtN2JkZC00YTc2LWE3MzgtNTllNWI4ZGQxYzM5In0.dgdCpC_ljerdJt_oJ_Icyt-Dr6bBCzwnnWAVQi-4Dc0";
     component.response = {
+      initiation: undefined,
       account: undefined,
       accounts: [],
-      pispName: "",
       clientId: "",
       clientName: "",
       intentType: undefined,
       logo: "",
-      merchantName: "",
+      serviceProviderName: "",
       redirectUri: "",
       username: "",
       decisionApiUri

--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/domestic-payment/domestic-payment.component.html
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/domestic-payment/domestic-payment.component.html
@@ -10,8 +10,10 @@
     <span [translate]="'CONSENT.PAYMENT.CHECK_DETAILS'"></span>
 
     <app-consent-box [items]="items"></app-consent-box>
+    <span *ngIf="response.initiation.debtorAccount" [translate]="'CONSENT.PAYMENT.ACCOUNT_PRE_SELECTED'"></span>
+    <app-consent-box *ngIf="response.initiation.debtorAccount" [items]="payerItems"></app-consent-box>
 
-    <app-account-selection
+    <app-account-selection *ngIf="!response.initiation.debtorAccount"
       [form]="form"
       [accounts]="response.accounts"
       [label]="'CONSENT.PAYMENT.SELECT_ACCOUNT'"

--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/domestic-payment/domestic-payment.component.spec.ts
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/domestic-payment/domestic-payment.component.spec.ts
@@ -1,20 +1,22 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { CommonModule } from '@angular/common';
-import { StoreModule } from '@ngrx/store';
-import { TranslateModule } from '@ngx-translate/core';
+import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {CommonModule} from '@angular/common';
+import {StoreModule} from '@ngrx/store';
+import {TranslateModule} from '@ngx-translate/core';
 
 import rootReducer from '../../../../../src/store';
-import { MatSharedModule } from '../../../../../src/app/mat-shared.module';
-import { TranslateSharedModule } from '../../../../../src/app/translate-shared.module';
-import { ForgerockSharedModule } from '@secureapigateway/secure-api-gateway-ob-uk-ui-common/shared';
-import { ForgerockCustomerLogoModule } from '@secureapigateway/secure-api-gateway-ob-uk-ui-common/components/forgerock-customer-logo';
-import { PermissionsComponent } from '../permissions/permissions.component';
-import { ConsentBoxComponentModule } from '../components/consent-box/consent-box.module';
-import { SubmitBoxComponentModule } from '../components/submit-box/submit-box.module';
-import { AccountCheckboxModule } from '../components/account-checkbox/account-checkbox.module';
-import { AccountSelectionComponentModule } from '../components/account-selection/account-selection.module';
+import {MatSharedModule} from '../../../../../src/app/mat-shared.module';
+import {TranslateSharedModule} from '../../../../../src/app/translate-shared.module';
+import {ForgerockSharedModule} from '@secureapigateway/secure-api-gateway-ob-uk-ui-common/shared';
+import {
+  ForgerockCustomerLogoModule
+} from '@secureapigateway/secure-api-gateway-ob-uk-ui-common/components/forgerock-customer-logo';
+import {PermissionsComponent} from '../permissions/permissions.component';
+import {ConsentBoxComponentModule} from '../components/consent-box/consent-box.module';
+import {SubmitBoxComponentModule} from '../components/submit-box/submit-box.module';
+import {AccountCheckboxModule} from '../components/account-checkbox/account-checkbox.module';
+import {AccountSelectionComponentModule} from '../components/account-selection/account-selection.module';
 
-import { DomesticPaymentComponent } from './domestic-payment.component';
+import {DomesticPaymentComponent} from './domestic-payment.component';
 import {ConsentDecision} from "../../../types/ConsentDecision";
 
 describe('app:bank DomesticPaymentComponent', () => {
@@ -35,7 +37,7 @@ describe('app:bank DomesticPaymentComponent', () => {
         SubmitBoxComponentModule,
         ConsentBoxComponentModule,
         AccountCheckboxModule,
-        AccountSelectionComponentModule
+        AccountSelectionComponentModule,
       ]
     }).compileComponents();
   }));
@@ -43,7 +45,19 @@ describe('app:bank DomesticPaymentComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(DomesticPaymentComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
+    component.response = {
+      account: undefined,
+      accounts: [],
+      clientId: "",
+      clientName: "",
+      decisionApiUri: "",
+      initiation: {},
+      intentType: undefined,
+      logo: "",
+      redirectUri: "",
+      serviceProviderName: "",
+      username: ""
+    };
   });
 
   it('should create', () => {
@@ -54,7 +68,6 @@ describe('app:bank DomesticPaymentComponent', () => {
     spyOn(component.formSubmit, 'emit');
 
     component.submit();
-    fixture.detectChanges();
 
     expect(component.formSubmit.emit).toHaveBeenCalledWith({
       decision: ConsentDecision.REJECTED,
@@ -64,15 +77,15 @@ describe('app:bank DomesticPaymentComponent', () => {
 
   it('should emit formSubmit decision deny', () => {
     const debtorAccount = {
-      "accountId":"a25606e1-00cc-4225-b662-f339229e3d59",
-      "currency":"GBP",
-      "nickname":"UK Bills",
-      "accounts":[
+      "accountId": "a25606e1-00cc-4225-b662-f339229e3d59",
+      "currency": "GBP",
+      "nickname": "UK Bills",
+      "accounts": [
         {
-          "schemeName":"UK.OBIE.SortCodeAccountNumber",
-          "identification":"4938761144202",
-          "name":"c417136f-91e4-4abe-985e-f757496e5458",
-          "secondaryIdentification":"17508172"
+          "schemeName": "UK.OBIE.SortCodeAccountNumber",
+          "identification": "4938761144202",
+          "name": "c417136f-91e4-4abe-985e-f757496e5458",
+          "secondaryIdentification": "17508172"
         }
       ]
     };
@@ -80,7 +93,6 @@ describe('app:bank DomesticPaymentComponent', () => {
     component.form.controls['selectedAccount'].setValue(debtorAccount);
 
     component.submit(false);
-    fixture.detectChanges();
 
     expect(component.formSubmit.emit).toHaveBeenCalledWith({
       decision: ConsentDecision.REJECTED,
@@ -90,15 +102,15 @@ describe('app:bank DomesticPaymentComponent', () => {
 
   it('should emit formSubmit decision allow', () => {
     const debtorAccount = {
-      "accountId":"a25606e1-00cc-4225-b662-f339229e3d59",
-      "currency":"GBP",
-      "nickname":"UK Bills",
-      "accounts":[
+      "accountId": "a25606e1-00cc-4225-b662-f339229e3d59",
+      "currency": "GBP",
+      "nickname": "UK Bills",
+      "accounts": [
         {
-          "schemeName":"UK.OBIE.SortCodeAccountNumber",
-          "identification":"4938761144202",
-          "name":"c417136f-91e4-4abe-985e-f757496e5458",
-          "secondaryIdentification":"17508172"
+          "schemeName": "UK.OBIE.SortCodeAccountNumber",
+          "identification": "4938761144202",
+          "name": "c417136f-91e4-4abe-985e-f757496e5458",
+          "secondaryIdentification": "17508172"
         }
       ]
     };
@@ -106,7 +118,6 @@ describe('app:bank DomesticPaymentComponent', () => {
     component.form.controls['selectedAccount'].setValue(debtorAccount);
 
     component.submit(true);
-    fixture.detectChanges();
 
     expect(component.formSubmit.emit).toHaveBeenCalledWith({
       decision: ConsentDecision.AUTHORISED,

--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/domestic-payment/domestic-payment.component.ts
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/domestic-payment/domestic-payment.component.ts
@@ -27,10 +27,35 @@ export class DomesticPaymentComponent implements OnInit {
   }
   @Output() formSubmit = new EventEmitter<IConsentEventEmitter>();
   items: Item[] = [];
+  payerItems: Item[] = [];
 
   ngOnInit() {
     if (!this.response) {
       return;
+    }
+
+    if (_get(this.response.initiation, 'debtorAccount')) {
+      // remove form control to enable it when not need select an account
+      this.form.removeControl('selectedAccount');
+      if (_get(this.response.initiation, 'debtorAccount.name')) {
+        this.payerItems.push({
+          type: ItemType.STRING,
+          payload: {
+            label: 'CONSENT.PAYMENT.NAME',
+            value: this.response.initiation.debtorAccount.name,
+            cssClass: 'domestic-single-payment-debtorAccount-Name'
+          }
+        });
+      }
+      this.payerItems.push({
+        type: ItemType.VRP_ACCOUNT_NUMBER,
+        payload: {
+          sortCodeLabel: 'CONSENT.PAYMENT.ACCOUNT_SORT_CODE',
+          accountNumberLabel: 'CONSENT.PAYMENT.ACCOUNT_NUMBER',
+          account: this.response.initiation.debtorAccount,
+          cssClass: 'domestic-single-payment-payer-account'
+        }
+      });
     }
 
     if (_get(this.response.initiation, 'creditorAccount')) {
@@ -72,7 +97,7 @@ export class DomesticPaymentComponent implements OnInit {
   submit(allowing = false) {
     this.formSubmit.emit({
       decision: allowing ? ConsentDecision.AUTHORISED : ConsentDecision.REJECTED,
-      debtorAccount: this.form.value.selectedAccount
+      debtorAccount: this.response.initiation.debtorAccount ? this.response.accounts[0].account : this.form.value.selectedAccount
     });
   }
 }

--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/domestic-schedule-payment/domestic-schedule-payment.component.html
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/domestic-schedule-payment/domestic-schedule-payment.component.html
@@ -13,8 +13,10 @@
     <span [translate]="'CONSENT.PAYMENT.CHECK_DETAILS'"></span>
 
     <app-consent-box [items]="items"></app-consent-box>
+    <span *ngIf="response.initiation.debtorAccount" [translate]="'CONSENT.PAYMENT.ACCOUNT_PRE_SELECTED'"></span>
+    <app-consent-box *ngIf="response.initiation.debtorAccount" [items]="payerItems"></app-consent-box>
 
-    <app-account-selection
+    <app-account-selection *ngIf="!response.initiation.debtorAccount"
       [form]="form"
       [accounts]="response.accounts"
       [label]="'CONSENT.PAYMENT.SELECT_ACCOUNT'"

--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/domestic-schedule-payment/domestic-schedule-payment.component.spec.ts
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/domestic-schedule-payment/domestic-schedule-payment.component.spec.ts
@@ -43,7 +43,19 @@ describe('app:bank DomesticSchedulePaymentComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(DomesticSchedulePaymentComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
+    component.response = {
+      account: undefined,
+      accounts: [],
+      clientId: "",
+      clientName: "",
+      decisionApiUri: "",
+      initiation: {},
+      intentType: undefined,
+      logo: "",
+      redirectUri: "",
+      serviceProviderName: "",
+      username: ""
+    };
   });
 
   it('should create', () => {
@@ -54,7 +66,6 @@ describe('app:bank DomesticSchedulePaymentComponent', () => {
     spyOn(component.formSubmit, 'emit');
 
     component.submit();
-    fixture.detectChanges();
 
     expect(component.formSubmit.emit).toHaveBeenCalledWith({
       decision: ConsentDecision.REJECTED,
@@ -80,7 +91,6 @@ describe('app:bank DomesticSchedulePaymentComponent', () => {
     component.form.controls['selectedAccount'].setValue(debtorAccount);
 
     component.submit(false);
-    fixture.detectChanges();
 
     expect(component.formSubmit.emit).toHaveBeenCalledWith({
       decision: ConsentDecision.REJECTED,
@@ -106,7 +116,6 @@ describe('app:bank DomesticSchedulePaymentComponent', () => {
     component.form.controls['selectedAccount'].setValue(debtorAccount);
 
     component.submit(true);
-    fixture.detectChanges();
 
     expect(component.formSubmit.emit).toHaveBeenCalledWith({
       decision: ConsentDecision.AUTHORISED,

--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/domestic-schedule-payment/domestic-schedule-payment.component.ts
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/domestic-schedule-payment/domestic-schedule-payment.component.ts
@@ -27,10 +27,35 @@ export class DomesticSchedulePaymentComponent implements OnInit {
   }
   @Output() formSubmit = new EventEmitter<IConsentEventEmitter>();
   items: Item[] = [];
+  payerItems: Item[] = [];
 
   ngOnInit() {
     if (!this.response) {
       return;
+    }
+
+    if (_get(this.response.initiation, 'debtorAccount')) {
+      // remove form control to enable it when not need select an account
+      this.form.removeControl('selectedAccount');
+      if (_get(this.response.initiation, 'debtorAccount.name')) {
+        this.payerItems.push({
+          type: ItemType.STRING,
+          payload: {
+            label: 'CONSENT.PAYMENT.NAME',
+            value: this.response.initiation.debtorAccount.name,
+            cssClass: 'domestic-schedule-payment-debtorAccount-Name'
+          }
+        });
+      }
+      this.payerItems.push({
+        type: ItemType.VRP_ACCOUNT_NUMBER,
+        payload: {
+          sortCodeLabel: 'CONSENT.PAYMENT.ACCOUNT_SORT_CODE',
+          accountNumberLabel: 'CONSENT.PAYMENT.ACCOUNT_NUMBER',
+          account: this.response.initiation.debtorAccount,
+          cssClass: 'domestic-schedule-payment-payer-account'
+        }
+      });
     }
 
     if (_get(this.response.initiation, 'creditorAccount')) {
@@ -76,7 +101,7 @@ export class DomesticSchedulePaymentComponent implements OnInit {
   submit(allowing = false) {
     this.formSubmit.emit({
       decision: allowing ? ConsentDecision.AUTHORISED : ConsentDecision.REJECTED,
-      debtorAccount: this.form.value.selectedAccount
+      debtorAccount: this.response.initiation.debtorAccount ? this.response.accounts[0].account : this.form.value.selectedAccount
     });
   }
 }

--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/domestic-standing-order/domestic-standing-order.component.html
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/domestic-standing-order/domestic-standing-order.component.html
@@ -14,8 +14,10 @@
     <span [translate]="'CONSENT.PAYMENT.CHECK_DETAILS'"></span>
 
     <app-consent-box [items]="items"></app-consent-box>
+    <span *ngIf="response.initiation.debtorAccount" [translate]="'CONSENT.PAYMENT.ACCOUNT_PRE_SELECTED'"></span>
+    <app-consent-box *ngIf="response.initiation.debtorAccount" [items]="payerItems"></app-consent-box>
 
-    <app-account-selection
+    <app-account-selection *ngIf="!response.initiation.debtorAccount"
       [form]="form"
       [accounts]="response.accounts"
       [label]="'CONSENT.PAYMENT.SELECT_ACCOUNT'"

--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/domestic-standing-order/domestic-standing-order.component.spec.ts
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/domestic-standing-order/domestic-standing-order.component.spec.ts
@@ -43,7 +43,20 @@ describe('app:bank DomesticStandingOrderComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(DomesticStandingOrderComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
+    component.response = {
+      account: undefined,
+      accounts: [],
+      clientId: "",
+      clientName: "",
+      decisionApiUri: "",
+      initiation: {},
+      intentType: undefined,
+      logo: "",
+      redirectUri: "",
+      serviceProviderName: "",
+      username: ""
+    };
+
   });
 
   it('should create', () => {
@@ -54,7 +67,7 @@ describe('app:bank DomesticStandingOrderComponent', () => {
     spyOn(component.formSubmit, 'emit');
 
     component.submit();
-    fixture.detectChanges();
+
 
     expect(component.formSubmit.emit).toHaveBeenCalledWith({
       decision: ConsentDecision.REJECTED,
@@ -80,7 +93,7 @@ describe('app:bank DomesticStandingOrderComponent', () => {
     component.form.controls['selectedAccount'].setValue(debtorAccount);
 
     component.submit(false);
-    fixture.detectChanges();
+
 
     expect(component.formSubmit.emit).toHaveBeenCalledWith({
       decision: ConsentDecision.REJECTED,
@@ -106,7 +119,7 @@ describe('app:bank DomesticStandingOrderComponent', () => {
     component.form.controls['selectedAccount'].setValue(debtorAccount);
 
     component.submit(true);
-    fixture.detectChanges();
+
 
     expect(component.formSubmit.emit).toHaveBeenCalledWith({
       decision: ConsentDecision.AUTHORISED,

--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/domestic-standing-order/domestic-standing-order.component.ts
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/domestic-standing-order/domestic-standing-order.component.ts
@@ -27,10 +27,35 @@ export class DomesticStandingOrderComponent implements OnInit {
   }
   @Output() formSubmit = new EventEmitter<IConsentEventEmitter>();
   items: Item[] = [];
+  payerItems: Item[] = [];
 
   ngOnInit() {
     if (!this.response) {
       return;
+    }
+
+    if (_get(this.response.initiation, 'debtorAccount')) {
+      // remove form control to enable it when not need select an account
+      this.form.removeControl('selectedAccount');
+      if (_get(this.response.initiation, 'debtorAccount.name')) {
+        this.payerItems.push({
+          type: ItemType.STRING,
+          payload: {
+            label: 'CONSENT.PAYMENT.NAME',
+            value: this.response.initiation.debtorAccount.name,
+            cssClass: 'domestic-single-payment-debtorAccount-Name'
+          }
+        });
+      }
+      this.payerItems.push({
+        type: ItemType.VRP_ACCOUNT_NUMBER,
+        payload: {
+          sortCodeLabel: 'CONSENT.PAYMENT.ACCOUNT_SORT_CODE',
+          accountNumberLabel: 'CONSENT.PAYMENT.ACCOUNT_NUMBER',
+          account: this.response.initiation.debtorAccount,
+          cssClass: 'domestic-single-payment-payer-account'
+        }
+      });
     }
 
     if (_get(this.response.initiation, 'creditorAccount')) {
@@ -109,7 +134,7 @@ export class DomesticStandingOrderComponent implements OnInit {
   submit(allowing = false) {
     this.formSubmit.emit({
       decision: allowing ? ConsentDecision.AUTHORISED : ConsentDecision.REJECTED,
-      debtorAccount: this.form.value.selectedAccount
+      debtorAccount: this.response.initiation.debtorAccount ? this.response.accounts[0].account : this.form.value.selectedAccount
     });
   }
 }

--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/file-payment/file-payment.component.html
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/file-payment/file-payment.component.html
@@ -11,7 +11,10 @@
 
     <app-consent-box [items]="items"></app-consent-box>
 
-    <app-account-selection
+    <span *ngIf="response.filePayment.debtorAccount" [translate]="'CONSENT.PAYMENT.ACCOUNT_PRE_SELECTED'"></span>
+    <app-consent-box *ngIf="response.filePayment.debtorAccount" [items]="payerItems"></app-consent-box>
+
+    <app-account-selection *ngIf="!response.filePayment.debtorAccount"
       [form]="form"
       [accounts]="response.accounts"
       [label]="'CONSENT.PAYMENT.SELECT_ACCOUNT'"

--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/file-payment/file-payment.component.spec.ts
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/file-payment/file-payment.component.spec.ts
@@ -43,7 +43,26 @@ describe('app:bank FilePaymentComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(FilePaymentComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
+    component.response = {
+      initiation: {},
+      account: undefined,
+      accounts: [],
+      clientId: "",
+      clientName: "",
+      decisionApiUri: "",
+      filePayment: {
+        fileReference: "XmlExample",
+        numberOfTransactions: "3",
+        controlSum: 11500000,
+        requestedExecutionDateTime: "2023-09-27T13:03:06.000Z"
+      },
+      intentType: undefined,
+      logo: "",
+      redirectUri: "",
+      serviceProviderName: "",
+      username: ""
+    };
+
   });
 
   it('should create', () => {
@@ -54,7 +73,7 @@ describe('app:bank FilePaymentComponent', () => {
     spyOn(component.formSubmit, 'emit');
 
     component.submit();
-    fixture.detectChanges();
+
 
     expect(component.formSubmit.emit).toHaveBeenCalledWith({
       decision: ConsentDecision.REJECTED,
@@ -80,7 +99,7 @@ describe('app:bank FilePaymentComponent', () => {
     component.form.controls['selectedAccount'].setValue(debtorAccount);
 
     component.submit(false);
-    fixture.detectChanges();
+
 
     expect(component.formSubmit.emit).toHaveBeenCalledWith({
       decision: ConsentDecision.REJECTED,
@@ -106,7 +125,7 @@ describe('app:bank FilePaymentComponent', () => {
     component.form.controls['selectedAccount'].setValue(debtorAccount);
 
     component.submit(true);
-    fixture.detectChanges();
+
 
     expect(component.formSubmit.emit).toHaveBeenCalledWith({
       decision: ConsentDecision.AUTHORISED,

--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/file-payment/file-payment.component.ts
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/file-payment/file-payment.component.ts
@@ -1,5 +1,6 @@
 import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { FormGroup, FormControl, Validators } from '@angular/forms';
+import _get from 'lodash-es/get';
 
 import { ApiResponses } from '../../../../../src/app/types/api';
 import { Item, ItemType, IConsentEventEmitter } from '../../../../../src/app/types/consentItem';
@@ -26,10 +27,35 @@ export class FilePaymentComponent implements OnInit {
   }
   @Output() formSubmit = new EventEmitter<IConsentEventEmitter>();
   items: Item[] = [];
+  payerItems: Item[] = [];
 
   ngOnInit() {
     if (!this.response) {
       return;
+    }
+
+    if (_get(this.response.filePayment, 'debtorAccount')) {
+      // remove form control to enable it when not need select an account
+      this.form.removeControl('selectedAccount');
+      if (_get(this.response.filePayment, 'debtorAccount.name')) {
+        this.payerItems.push({
+          type: ItemType.STRING,
+          payload: {
+            label: 'CONSENT.PAYMENT.NAME',
+            value: this.response.filePayment.debtorAccount.name,
+            cssClass: 'domestic-single-payment-debtorAccount-Name'
+          }
+        });
+      }
+      this.payerItems.push({
+        type: ItemType.VRP_ACCOUNT_NUMBER,
+        payload: {
+          sortCodeLabel: 'CONSENT.PAYMENT.ACCOUNT_SORT_CODE',
+          accountNumberLabel: 'CONSENT.PAYMENT.ACCOUNT_NUMBER',
+          account: this.response.filePayment.debtorAccount,
+          cssClass: 'domestic-single-payment-payer-account'
+        }
+      });
     }
 
     this.items.push({
@@ -80,7 +106,7 @@ export class FilePaymentComponent implements OnInit {
   submit(allowing = false) {
     this.formSubmit.emit({
       decision: allowing ? ConsentDecision.AUTHORISED : ConsentDecision.REJECTED,
-      debtorAccount: this.form.value.selectedAccount
+      debtorAccount: this.response.filePayment.debtorAccount ? this.response.accounts[0].account : this.form.value.selectedAccount
     });
   }
 }

--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/funds-confirmation/funds-confirmation.component.spec.ts
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/funds-confirmation/funds-confirmation.component.spec.ts
@@ -89,7 +89,7 @@ describe('app:bank FundsConfirmationComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(FundsConfirmationComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
+
   });
 
   it('should create', () => {
@@ -100,7 +100,7 @@ describe('app:bank FundsConfirmationComponent', () => {
     spyOn(component.formSubmit, 'emit');
 
     component.submit();
-    fixture.detectChanges();
+
 
     expect(component.formSubmit.emit).toHaveBeenCalledWith({
       decision: ConsentDecision.REJECTED,
@@ -115,7 +115,7 @@ describe('app:bank FundsConfirmationComponent', () => {
     component.response = responseObject
 
     component.submit(false);
-    fixture.detectChanges();
+
 
     expect(component.formSubmit.emit).toHaveBeenCalledWith({
       decision: ConsentDecision.REJECTED,
@@ -130,7 +130,7 @@ describe('app:bank FundsConfirmationComponent', () => {
     component.response = responseObject
 
     component.submit(true);
-    fixture.detectChanges();
+
 
     expect(component.formSubmit.emit).toHaveBeenCalledWith({
       decision: ConsentDecision.AUTHORISED,

--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/international-payment/international-payment.component.html
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/international-payment/international-payment.component.html
@@ -17,8 +17,10 @@
     <div class="title">{{ 'CONSENT.INTERNATIONAL-PAYMENT.REFRESH_RATE_INFO' | translate }}</div>
 
     <app-consent-box [items]="rateItems"></app-consent-box>
+    <span *ngIf="response.initiation.debtorAccount" [translate]="'CONSENT.PAYMENT.ACCOUNT_PRE_SELECTED'"></span>
+    <app-consent-box *ngIf="response.initiation.debtorAccount" [items]="payerItems"></app-consent-box>
 
-    <app-account-selection
+    <app-account-selection *ngIf="!response.initiation.debtorAccount"
       [form]="form"
       [accounts]="response.accounts"
       [label]="'CONSENT.PAYMENT.SELECT_ACCOUNT'"

--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/international-payment/international-payment.component.spec.ts
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/international-payment/international-payment.component.spec.ts
@@ -43,7 +43,20 @@ describe('app:bank InternationalPaymentComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(InternationalPaymentComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
+    component.response = {
+      account: undefined,
+      accounts: [],
+      clientId: "",
+      clientName: "",
+      decisionApiUri: "",
+      initiation: {},
+      intentType: undefined,
+      logo: "",
+      redirectUri: "",
+      serviceProviderName: "",
+      username: ""
+    };
+
   });
 
   it('should create', () => {
@@ -54,7 +67,7 @@ describe('app:bank InternationalPaymentComponent', () => {
     spyOn(component.formSubmit, 'emit');
 
     component.submit();
-    fixture.detectChanges();
+
 
     expect(component.formSubmit.emit).toHaveBeenCalledWith({
       decision: ConsentDecision.REJECTED,
@@ -80,7 +93,7 @@ describe('app:bank InternationalPaymentComponent', () => {
     component.form.controls['selectedAccount'].setValue(debtorAccount);
 
     component.submit(false);
-    fixture.detectChanges();
+
 
     expect(component.formSubmit.emit).toHaveBeenCalledWith({
       decision: ConsentDecision.REJECTED,
@@ -106,7 +119,7 @@ describe('app:bank InternationalPaymentComponent', () => {
     component.form.controls['selectedAccount'].setValue(debtorAccount);
 
     component.submit(true);
-    fixture.detectChanges();
+
 
     expect(component.formSubmit.emit).toHaveBeenCalledWith({
       decision: ConsentDecision.AUTHORISED,

--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/international-payment/international-payment.component.ts
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/international-payment/international-payment.component.ts
@@ -28,10 +28,35 @@ export class InternationalPaymentComponent implements OnInit {
   @Output() formSubmit = new EventEmitter<IConsentEventEmitter>();
   basicItems: Item[] = [];
   rateItems: Item[] = [];
+  payerItems: Item[] = [];
 
   ngOnInit() {
     if (!this.response) {
       return;
+    }
+
+    if (_get(this.response.initiation, 'debtorAccount')) {
+      // remove form control to enable it when not need select an account
+      this.form.removeControl('selectedAccount');
+      if (_get(this.response.initiation, 'debtorAccount.name')) {
+        this.payerItems.push({
+          type: ItemType.STRING,
+          payload: {
+            label: 'CONSENT.PAYMENT.NAME',
+            value: this.response.initiation.debtorAccount.name,
+            cssClass: 'domestic-single-payment-debtorAccount-Name'
+          }
+        });
+      }
+      this.payerItems.push({
+        type: ItemType.VRP_ACCOUNT_NUMBER,
+        payload: {
+          sortCodeLabel: 'CONSENT.PAYMENT.ACCOUNT_SORT_CODE',
+          accountNumberLabel: 'CONSENT.PAYMENT.ACCOUNT_NUMBER',
+          account: this.response.initiation.debtorAccount,
+          cssClass: 'domestic-single-payment-payer-account'
+        }
+      });
     }
 
     if (_get(this.response.initiation, 'creditorAccount')) {
@@ -149,7 +174,7 @@ export class InternationalPaymentComponent implements OnInit {
   submit(allowing = false) {
     this.formSubmit.emit({
       decision: allowing ? ConsentDecision.AUTHORISED : ConsentDecision.REJECTED,
-      debtorAccount: this.form.value.selectedAccount
+      debtorAccount: this.response.initiation.debtorAccount ? this.response.accounts[0].account : this.form.value.selectedAccount
     });
   }
 }

--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/international-schedule-payment/international-schedule-payment.component.html
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/international-schedule-payment/international-schedule-payment.component.html
@@ -17,8 +17,10 @@
     <div class="title">{{ 'CONSENT.INTERNATIONAL-PAYMENT.REFRESH_RATE_INFO' | translate }}</div>
 
     <app-consent-box [items]="rateItems"></app-consent-box>
+    <span *ngIf="response.initiation.debtorAccount" [translate]="'CONSENT.PAYMENT.ACCOUNT_PRE_SELECTED'"></span>
+    <app-consent-box *ngIf="response.initiation.debtorAccount" [items]="payerItems"></app-consent-box>
 
-    <app-account-selection
+    <app-account-selection *ngIf="!response.initiation.debtorAccount"
       [form]="form"
       [accounts]="response.accounts"
       [label]="'CONSENT.PAYMENT.SELECT_ACCOUNT'"

--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/international-schedule-payment/international-schedule-payment.component.spec.ts
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/international-schedule-payment/international-schedule-payment.component.spec.ts
@@ -43,7 +43,19 @@ describe('app:bank InternationalSchedulePaymentComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(InternationalSchedulePaymentComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
+    component.response = {
+      account: undefined,
+      accounts: [],
+      clientId: "",
+      clientName: "",
+      decisionApiUri: "",
+      initiation: {},
+      intentType: undefined,
+      logo: "",
+      redirectUri: "",
+      serviceProviderName: "",
+      username: ""
+    };
   });
 
   it('should create', () => {
@@ -54,7 +66,7 @@ describe('app:bank InternationalSchedulePaymentComponent', () => {
     spyOn(component.formSubmit, 'emit');
 
     component.submit();
-    fixture.detectChanges();
+
 
     expect(component.formSubmit.emit).toHaveBeenCalledWith({
       decision: ConsentDecision.REJECTED,
@@ -80,7 +92,7 @@ describe('app:bank InternationalSchedulePaymentComponent', () => {
     component.form.controls['selectedAccount'].setValue(debtorAccount);
 
     component.submit(false);
-    fixture.detectChanges();
+
 
     expect(component.formSubmit.emit).toHaveBeenCalledWith({
       decision: ConsentDecision.REJECTED,
@@ -106,7 +118,6 @@ describe('app:bank InternationalSchedulePaymentComponent', () => {
     component.form.controls['selectedAccount'].setValue(debtorAccount);
 
     component.submit(true);
-    fixture.detectChanges();
 
     expect(component.formSubmit.emit).toHaveBeenCalledWith({
       decision: ConsentDecision.AUTHORISED,

--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/international-schedule-payment/international-schedule-payment.component.ts
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/international-schedule-payment/international-schedule-payment.component.ts
@@ -28,10 +28,35 @@ export class InternationalSchedulePaymentComponent implements OnInit {
   @Output() formSubmit = new EventEmitter<IConsentEventEmitter>();
   basicItems: Item[] = [];
   rateItems: Item[] = [];
+  payerItems: Item[] = [];
 
   ngOnInit() {
     if (!this.response) {
       return;
+    }
+
+    if (_get(this.response.initiation, 'debtorAccount')) {
+      // remove form control to enable it when not need select an account
+      this.form.removeControl('selectedAccount');
+      if (_get(this.response.initiation, 'debtorAccount.name')) {
+        this.payerItems.push({
+          type: ItemType.STRING,
+          payload: {
+            label: 'CONSENT.PAYMENT.NAME',
+            value: this.response.initiation.debtorAccount.name,
+            cssClass: 'domestic-single-payment-debtorAccount-Name'
+          }
+        });
+      }
+      this.payerItems.push({
+        type: ItemType.VRP_ACCOUNT_NUMBER,
+        payload: {
+          sortCodeLabel: 'CONSENT.PAYMENT.ACCOUNT_SORT_CODE',
+          accountNumberLabel: 'CONSENT.PAYMENT.ACCOUNT_NUMBER',
+          account: this.response.initiation.debtorAccount,
+          cssClass: 'domestic-single-payment-payer-account'
+        }
+      });
     }
 
     if (_get(this.response.initiation, 'creditorAccount')) {
@@ -160,7 +185,7 @@ export class InternationalSchedulePaymentComponent implements OnInit {
   submit(allowing = false) {
     this.formSubmit.emit({
       decision: allowing ? ConsentDecision.AUTHORISED : ConsentDecision.REJECTED,
-      debtorAccount: this.form.value.selectedAccount
+      debtorAccount: this.response.initiation.debtorAccount ? this.response.accounts[0].account : this.form.value.selectedAccount
     });
   }
 }

--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/international-standing-order/international-standing-order.component.html
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/international-standing-order/international-standing-order.component.html
@@ -13,8 +13,10 @@
     <span [translate]="'CONSENT.PAYMENT.CHECK_DETAILS'"></span>
 
     <app-consent-box [items]="items"></app-consent-box>
+    <span *ngIf="response.initiation.debtorAccount" [translate]="'CONSENT.PAYMENT.ACCOUNT_PRE_SELECTED'"></span>
+    <app-consent-box *ngIf="response.initiation.debtorAccount" [items]="payerItems"></app-consent-box>
 
-    <app-account-selection
+    <app-account-selection *ngIf="!response.initiation.debtorAccount"
       [form]="form"
       [accounts]="response.accounts"
       [label]="'CONSENT.PAYMENT.SELECT_ACCOUNT'"

--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/international-standing-order/international-standing-order.component.spec.ts
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/international-standing-order/international-standing-order.component.spec.ts
@@ -43,7 +43,20 @@ describe('app:bank InternationalStandingOrderComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(InternationalStandingOrderComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
+    component.response = {
+      account: undefined,
+      accounts: [],
+      clientId: "",
+      clientName: "",
+      decisionApiUri: "",
+      initiation: {},
+      intentType: undefined,
+      logo: "",
+      redirectUri: "",
+      serviceProviderName: "",
+      username: ""
+    };
+
   });
 
   it('should create', () => {
@@ -54,7 +67,7 @@ describe('app:bank InternationalStandingOrderComponent', () => {
     spyOn(component.formSubmit, 'emit');
 
     component.submit();
-    fixture.detectChanges();
+
 
     expect(component.formSubmit.emit).toHaveBeenCalledWith({
       decision: ConsentDecision.REJECTED,
@@ -80,7 +93,7 @@ describe('app:bank InternationalStandingOrderComponent', () => {
     component.form.controls['selectedAccount'].setValue(debtorAccount);
 
     component.submit(false);
-    fixture.detectChanges();
+
 
     expect(component.formSubmit.emit).toHaveBeenCalledWith({
       decision: ConsentDecision.REJECTED,
@@ -106,7 +119,7 @@ describe('app:bank InternationalStandingOrderComponent', () => {
     component.form.controls['selectedAccount'].setValue(debtorAccount);
 
     component.submit(true);
-    fixture.detectChanges();
+
 
     expect(component.formSubmit.emit).toHaveBeenCalledWith({
       decision: ConsentDecision.AUTHORISED,

--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/international-standing-order/international-standing-order.component.ts
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/international-standing-order/international-standing-order.component.ts
@@ -27,10 +27,35 @@ export class InternationalStandingOrderComponent implements OnInit {
   }
   @Output() formSubmit = new EventEmitter<IConsentEventEmitter>();
   items: Item[] = [];
+  payerItems: Item[] = [];
 
   ngOnInit() {
     if (!this.response) {
       return;
+    }
+
+    if (_get(this.response.initiation, 'debtorAccount')) {
+      // remove form control to enable it when not need select an account
+      this.form.removeControl('selectedAccount');
+      if (_get(this.response.initiation, 'debtorAccount.name')) {
+        this.payerItems.push({
+          type: ItemType.STRING,
+          payload: {
+            label: 'CONSENT.PAYMENT.NAME',
+            value: this.response.initiation.debtorAccount.name,
+            cssClass: 'domestic-single-payment-debtorAccount-Name'
+          }
+        });
+      }
+      this.payerItems.push({
+        type: ItemType.VRP_ACCOUNT_NUMBER,
+        payload: {
+          sortCodeLabel: 'CONSENT.PAYMENT.ACCOUNT_SORT_CODE',
+          accountNumberLabel: 'CONSENT.PAYMENT.ACCOUNT_NUMBER',
+          account: this.response.initiation.debtorAccount,
+          cssClass: 'domestic-single-payment-payer-account'
+        }
+      });
     }
 
     if (_get(this.response.initiation, 'creditorAccount')) {
@@ -111,7 +136,7 @@ export class InternationalStandingOrderComponent implements OnInit {
   submit(allowing = false) {
     this.formSubmit.emit({
       decision: allowing ? ConsentDecision.AUTHORISED : ConsentDecision.REJECTED,
-      debtorAccount: this.form.value.selectedAccount
+      debtorAccount: this.response.initiation.debtorAccount ? this.response.accounts[0].account : this.form.value.selectedAccount
     });
   }
 }

--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/single-payment/single-payment.component.html
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/single-payment/single-payment.component.html
@@ -10,8 +10,10 @@
     <span [translate]="'CONSENT.PAYMENT.CHECK_DETAILS'"></span>
 
     <app-consent-box [items]="items"></app-consent-box>
+    <span *ngIf="response.initiation.debtorAccount" [translate]="'CONSENT.PAYMENT.ACCOUNT_PRE_SELECTED'"></span>
+    <app-consent-box *ngIf="response.initiation.debtorAccount" [items]="payerItems"></app-consent-box>
 
-    <app-account-selection
+    <app-account-selection *ngIf="!response.initiation.debtorAccount"
       [form]="form"
       [accounts]="response.accounts"
       [label]="'CONSENT.PAYMENT.SELECT_ACCOUNT'"

--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/single-payment/single-payment.component.spec.ts
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/single-payment/single-payment.component.spec.ts
@@ -43,7 +43,20 @@ describe('app:bank SinglePaymentComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(SinglePaymentComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
+    component.response = {
+      account: undefined,
+      accounts: [],
+      clientId: "",
+      clientName: "",
+      decisionApiUri: "",
+      initiation: {},
+      intentType: undefined,
+      logo: "",
+      redirectUri: "",
+      serviceProviderName: "",
+      username: ""
+    };
+
   });
 
   it('should create', () => {
@@ -54,7 +67,7 @@ describe('app:bank SinglePaymentComponent', () => {
     spyOn(component.formSubmit, 'emit');
 
     component.submit();
-    fixture.detectChanges();
+
 
     expect(component.formSubmit.emit).toHaveBeenCalledWith({
       decision: ConsentDecision.REJECTED,
@@ -80,7 +93,7 @@ describe('app:bank SinglePaymentComponent', () => {
     component.form.controls['selectedAccount'].setValue(debtorAccount);
 
     component.submit(false);
-    fixture.detectChanges();
+
 
     expect(component.formSubmit.emit).toHaveBeenCalledWith({
       decision: ConsentDecision.REJECTED,
@@ -106,7 +119,7 @@ describe('app:bank SinglePaymentComponent', () => {
     component.form.controls['selectedAccount'].setValue(debtorAccount);
 
     component.submit(true);
-    fixture.detectChanges();
+
 
     expect(component.formSubmit.emit).toHaveBeenCalledWith({
       decision: ConsentDecision.AUTHORISED,

--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/vrp-payment/vrp-payment.component.html
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/vrp-payment/vrp-payment.component.html
@@ -13,10 +13,10 @@
     <app-consent-box [items]="payeeItems"></app-consent-box>
     <span [translate]="'CONSENT.VRP-PAYMENT.PAYMENT_RULES'"></span>
     <app-consent-box [items]="paymentRulesItems"></app-consent-box>
-    <span *ngIf="isDebtorAccount" [translate]="'CONSENT.VRP-PAYMENT.FROM'"></span>
-    <app-consent-box *ngIf="isDebtorAccount" [items]="payerItems"></app-consent-box>
+    <span *ngIf="response.initiation.debtorAccount" [translate]="'CONSENT.VRP-PAYMENT.FROM'"></span>
+    <app-consent-box *ngIf="response.initiation.debtorAccount" [items]="payerItems"></app-consent-box>
 
-    <app-account-selection *ngIf="!isDebtorAccount"
+    <app-account-selection *ngIf="!response.initiation.debtorAccount"
       [form]="form"
       [accounts]="response.accounts"
       [label]="'CONSENT.PAYMENT.SELECT_ACCOUNT'"

--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/vrp-payment/vrp-payment.component.spec.ts
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/vrp-payment/vrp-payment.component.spec.ts
@@ -43,7 +43,6 @@ describe('VrpPaymentComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(VrpPaymentComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
   });
 
   it('should create', () => {

--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/vrp-payment/vrp-payment.component.ts
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/vrp-payment/vrp-payment.component.ts
@@ -32,7 +32,6 @@ export class VrpPaymentComponent implements OnInit {
   payerItems: Item[] = [];
   payeeItems: Item[] = [];
   paymentRulesItems: Item[] = [];
-  isDebtorAccount = false;
 
   ngOnInit() {
     console.log("vrp payment component")
@@ -41,7 +40,6 @@ export class VrpPaymentComponent implements OnInit {
     }
     // PAYER ITEMS
     if (_get(this.response.initiation, 'debtorAccount')) {
-      this.isDebtorAccount = true;
       // remove form control to enable it when not need select an account
       this.form.removeControl('selectedAccount');
       if (_get(this.response.initiation, 'debtorAccount.name')) {
@@ -164,7 +162,7 @@ export class VrpPaymentComponent implements OnInit {
   submit(allowing = false) {
     this.formSubmit.emit({
       decision: allowing ? ConsentDecision.AUTHORISED : ConsentDecision.REJECTED,
-      debtorAccount: this.isDebtorAccount ? this.response.accounts[0].account : this.form.value.selectedAccount
+      debtorAccount: this.response.initiation.debtorAccount ? this.response.accounts[0].account : this.form.value.selectedAccount
     });
   }
 

--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/types/api.ts
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/types/api.ts
@@ -27,7 +27,7 @@ export module ApiResponses {
     fromTransaction?: string;
     toTransaction?: string;
     account: OBAccount2;
-    initiation: Initiation; // VRP payment
+    initiation: Initiation;
     controlParameters?: ControlParameters; // vrp payment
     standingOrder?: {
       frequency: string;
@@ -50,6 +50,7 @@ export module ApiResponses {
       numberOfTransactions: string;
       controlSum: number;
       requestedExecutionDateTime: string;
+      debtorAccount?: OBCashAccount3;
     }
     paymentDate?: string; // domestic scheduled payment
     instructedAmount?: OBActiveOrHistoricCurrencyAndAmount;

--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/assets/i18n/en.json
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/assets/i18n/en.json
@@ -42,7 +42,10 @@
       "CURRENCY": "Currency",
       "CURRENCY_FROM": "From currency",
       "CURRENCY_TO": "To currency",
-      "CHARGES": "Charges"
+      "CHARGES": "Charges",
+      "NAME": "Name",
+      "ACCOUNT_NUMBER": "Account Number",
+      "ACCOUNT_SORT_CODE": "Sort Code"
     },
     "VRP-PAYMENT": {
       "TITLE": "Variable Recurring Payment",

--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/assets/i18n/es.json
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/assets/i18n/es.json
@@ -35,13 +35,16 @@
       "ACCOUNT_PRE_SELECTED": "De la cuenta",
       "SELECT_ACCOUNT": "Por favor seleccione la cuenta de pago:",
       "AVAILABLE": "Disponible",
-      "PROCEED_PAYMENT": "Presione proceeder para realizar el pago",
+      "PROCEED_PAYMENT": "Presione proceder para realizar el pago",
       "PROCEED": "Proceder",
       "CANCEL": "Cancelar",
       "CURRENCY": "Divisa",
       "CURRENCY_FROM": "De divisa",
       "CURRENCY_TO": "A divisa",
-      "CHARGES": "Cargos"
+      "CHARGES": "Cargos",
+      "NAME": "Nombre",
+      "ACCOUNT_NUMBER": "Número de cuenta",
+      "ACCOUNT_SORT_CODE": "Código de clasificación"
     },
     "VRP-PAYMENT": {
       "TITLE": "Variable Recurring Payment",


### PR DESCRIPTION
- Fixed preselected account when the debtor account is provided in the consent details
- Updated the decision response to inform the backend with the debtor account Id or the account Id chosen by the user.
Issue: https://github.com/secureapigateway/secureapigateway/issues/947