### PR TITLE
995: prepare release 1.0.2

### DIFF
--- a/_infra/helm/securebanking-ui/Chart.yaml
+++ b/_infra/helm/securebanking-ui/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: remote-consent-service-user-interface
 description: RCS UI Helm chart for Kubernetes
 type: application
-version: 1.0.2
-appVersion: 1.0.2
+version: 1.0.3
+appVersion: 1.0.3


### PR DESCRIPTION
- Updated helm chart to 1.0.3
- Align rcs-ui version to 1.0.3

Issue: https://github.com/secureapigateway/secureapigateway/issues/995