### PR TITLE
1032: Updating VRP details types to use decode FR data model types

### DIFF
--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent-dev/mocks/debtorAccountProvided/vrp-payment-consent-details.js
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent-dev/mocks/debtorAccountProvided/vrp-payment-consent-details.js
@@ -62,24 +62,24 @@ module.exports = {
     }
   ],
   controlParameters: {
-    ValidFromDateTime: "2022-11-28T11:35:30.510Z",
-    ValidToDateTime: "2022-11-28T11:35:30.510Z",
-    MaximumIndividualAmount: {
-      Amount: "10.01",
-      Currency: "GBP"
+    validFromDateTime: "2022-11-28T11:35:30.510Z",
+    validToDateTime: "2022-11-28T11:35:30.510Z",
+    maximumIndividualAmount: {
+      amount: "10.01",
+      currency: "GBP"
     },
-    PeriodicLimits: [
+    periodicLimits: [
       {
-        PeriodType: "Month",
-        PeriodAlignment: "Calendar",
-        Amount: "10.01",
-        Currency: "GBP"
+        periodType: "Month",
+        periodAlignment: "Calendar",
+        amount: "10.01",
+        currency: "GBP"
       }
     ],
-    VRPType: [
+    vrpType: [
       "UK.OBIE.VRPType.Sweeping"
     ],
-    PSUAuthenticationMethods: [
+    psuAuthenticationMethods: [
       "UK.OBIE.SCANotRequired"
     ]
   },

--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/vrp-payment/vrp-payment.component.ts
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/vrp-payment/vrp-payment.component.ts
@@ -121,38 +121,38 @@ export class VrpPaymentComponent implements OnInit {
 
 
     // Payment rules (Control parameter items)
-    if (_get(this.response.controlParameters, 'PeriodicLimits[0]')) {
+    if (_get(this.response.controlParameters, 'periodicLimits[0]')) {
       const periodicLimitsInstructedAmount = {
-        amount: this.response.controlParameters.PeriodicLimits[0].Amount,
-        currency: this.response.controlParameters.PeriodicLimits[0].Currency
+        amount: this.response.controlParameters.periodicLimits[0].amount,
+        currency: this.response.controlParameters.periodicLimits[0].currency
       }
       this.paymentRulesItems.push({
         type: ItemType.INSTRUCTED_AMOUNT,
         payload: {
           label: this.translate.instant('CONSENT.VRP-PAYMENT.MAX_AMOUNT_PERIOD_TYPE', {
-            periodType: this.response.controlParameters.PeriodicLimits[0].PeriodType
+            periodType: this.response.controlParameters.periodicLimits[0].periodType
           }),
           amount: periodicLimitsInstructedAmount,
           cssClass: 'vrp-payment-maxAmountPeriod'
         }
       });
     }
-    if (_get(this.response.controlParameters, 'MaximumIndividualAmount')) {
+    if (_get(this.response.controlParameters, 'maximumIndividualAmount')) {
       this.paymentRulesItems.push({
         type: ItemType.MAXIMUM_INDIVIDUAL_AMOUNT,
         payload: {
           label: 'CONSENT.VRP-PAYMENT.MAX_AMOUNT_PER_PAYMENT',
-          amount: this.response.controlParameters.MaximumIndividualAmount,
+          amount: this.response.controlParameters.maximumIndividualAmount,
           cssClass: 'vrp-payment-maxAmountPerPayment'
         }
       });
     }
-    if (_get(this.response.controlParameters, 'ValidToDateTime')) {
+    if (_get(this.response.controlParameters, 'validToDateTime')) {
       this.paymentRulesItems.push({
         type: ItemType.DATE,
         payload: {
           label: 'CONSENT.VRP-PAYMENT.EXPIRE',
-          date: this.response.controlParameters.ValidToDateTime,
+          date: this.response.controlParameters.validToDateTime,
           cssClass: 'vrp-payment-validToDateTime'
         }
       });

--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pipes/maximum-amount.pipe.ts
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pipes/maximum-amount.pipe.ts
@@ -14,10 +14,10 @@ export class MaximumAmountFormatPipe implements PipeTransform {
     const local = this.translateService.getBrowserCultureLang() || 'en-UK';
     const formatter = new Intl.NumberFormat(local, {
       style: 'currency',
-      currency: amount.Currency,
+      currency: amount.currency,
       minimumFractionDigits: 2
     });
 
-    return formatter.format(amount.Amount);
+    return formatter.format(amount.amount);
   }
 }

--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/types/api.ts
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/types/api.ts
@@ -1,4 +1,10 @@
-import {OBAccount2, OBActiveOrHistoricCurrencyAndAmount, OBCashAccount3, OBCashBalance1} from './ob';
+import {
+  MaximumIndividualAmount,
+  OBAccount2,
+  OBActiveOrHistoricCurrencyAndAmount,
+  OBCashAccount3,
+  OBCashBalance1
+} from './ob';
 import {IntentType} from '../../../src/app/types/IntentType';
 import {OBAccountPermissions} from '../../../src/app/types/OBAccountPermissions';
 
@@ -87,19 +93,19 @@ export class Rate {
 }
 
 export class ControlParameters {
-  ValidFromDateTime?: string;
-  ValidToDateTime?: string;
-  MaximumIndividualAmount?:OBActiveOrHistoricCurrencyAndAmount;
-  PeriodicLimits?: PeriodicLimits;
-  VRPType: string[];
-  PSUAuthenticationMethods: string[];
+  validFromDateTime?: string;
+  validToDateTime?: string;
+  maximumIndividualAmount?:MaximumIndividualAmount;
+  periodicLimits?: PeriodicLimits;
+  vrpType: string[];
+  psuAuthenticationMethods: string[];
 }
 
 export class PeriodicLimits {
-  PeriodType?: string;
-  PeriodAlignment?: string;
-  Amount?: number;
-  Currency?: string;
+  periodType?: string;
+  periodAlignment?: string;
+  amount?: number;
+  currency?: string;
 }
 
 export class Charges {

--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/types/ob.ts
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/types/ob.ts
@@ -20,8 +20,8 @@ export class OBActiveOrHistoricCurrencyAndAmount {
 }
 
 export class MaximumIndividualAmount {
-  Amount?: number;
-  Currency?: string;
+  amount?: number;
+  currency?: string;
 }
 
 export interface OBCashBalance1 {


### PR DESCRIPTION
The RCS API has updated the controlParameters from OBDomesticVRPControlParameters to FRDomesticVRPControlParameters. See https://github.com/SecureApiGateway/secure-api-gateway-ob-uk-rcs/pull/146

Updating UI types to be able to decode the change in json.

Issue: https://github.com/SecureApiGateway/secure-api-gateway-ob-uk-rcs/pull/1032