### PR TITLE
1040: prepare helm chart version to build the release 1.0.3

### DIFF
--- a/_infra/helm/securebanking-ui/Chart.yaml
+++ b/_infra/helm/securebanking-ui/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: remote-consent-service-user-interface
 description: RCS UI Helm chart for Kubernetes
 type: application
-version: 1.0.3
-appVersion: 1.0.3
+version: 1.0.4
+appVersion: 1.0.4


### PR DESCRIPTION
- Updated helm chart version to 1.0.4

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1040