### PR TITLE
1026: missed standing order (domestic and international) display consent details

### DIFF
--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent-dev/mocks/debtorAccountProvided/domestic-standing-order-response-details.js
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent-dev/mocks/debtorAccountProvided/domestic-standing-order-response-details.js
@@ -1,83 +1,81 @@
 module.exports = {
-  type: "DomesticStandingOrderConsentDetails",
-  decisionApiUri: "/rcs/api/consent/decision/",
-  username: "psu4test",
-  userId: "42edfd13-a642-47c1-b76c-684efe4e6449",
-  logo: "https://forgerock.com",
-  clientId: "63bce7d3-0c74-4188-9d24-88e3a69d3c80",
-  clientName: "TPP Test application",
-  serviceProviderName: "Forgerock Bank simulation config",
-  initiation: {
-    debtorAccount: {
-      schemeName: "UK.OBIE.SortCodeAccountNumber",
-      identification: "30772183765717",
-      name: "Will Smith account",
-      secondaryIdentification: "66234289"
-    },
-    creditorAccount: {
-      schemeName: "UK.OBIE.SortCodeAccountNumber",
-      identification: "08080021325698",
-      name: "ACME Inc",
-      secondaryIdentification: "0002"
-    }
-  },
-  standingOrder: {
-      type: "FRWriteDomesticStandingOrderDataInitiation",
-      frequency: "Paid on the 25th March, 24th June, 29th September and 25th December.",
-      firstPaymentDateTime: "2022-06-21T06:06:06.000Z",
-      finalPaymentDateTime: "2023-03-20T06:06:06.000Z",
-      firstPaymentAmount: {
-          amount: "165.88",
-          currency: "GBP"
-      },
-      recurringPaymentAmount: {
-          amount: "165.88",
-          currency: "GBP"
-      },
-      finalPaymentAmount: {
-          amount: "165.88",
-          currency: "GBP"
-      }
-  },
-  accounts: [
-    {
-      id: "cdb062f6-daed-479a-8843-00f842926ef7",
-      userId: "7b78b560-6057-41c5-bf1f-1ed590b1c30b",
-      account: {
-        accountId: "cdb062f6-daed-479a-8843-00f842926ef7",
-        status: "Enabled",
-        statusUpdateDateTime: "2022-04-01T11:35:15.368Z",
-        currency: "GBP",
-        accountType: "Personal",
-        accountSubType: "CurrentAccount",
-        nickname: "UK Bills",
-        openingDate: "2022-03-31T11:35:15.368Z",
-        maturityDate: "2022-04-02T11:35:15.368Z",
-        accounts: [
-          {
+    type: "DomesticStandingOrderConsentDetails",
+    decisionApiUri: "/rcs/api/consent/decision/",
+    username: "psu4test",
+    userId: "42edfd13-a642-47c1-b76c-684efe4e6449",
+    logo: "https://forgerock.com",
+    clientId: "63bce7d3-0c74-4188-9d24-88e3a69d3c80",
+    clientName: "TPP Test application",
+    serviceProviderName: "Forgerock Bank simulation config",
+    initiation: {
+        debtorAccount: {
             schemeName: "UK.OBIE.SortCodeAccountNumber",
             identification: "30772183765717",
             name: "Will Smith account",
             secondaryIdentification: "66234289"
-          }
-        ]
-      },
-      latestStatementId: "995af620-0f5c-4071-a7ca-6591038d12c4",
-      created: "2022-04-01T11:35:15.368Z",
-      balances: [
-        {
-          accountId: "cdb062f6-daed-479a-8843-00f842926ef7",
-          creditDebitIndicator: "Debit",
-          type: "InterimAvailable",
-          dateTime: "2022-04-01T11:35:15.373Z",
-          amount: {
-            amount: "1679.63",
+        },
+        creditorAccount: {
+            schemeName: "UK.OBIE.SortCodeAccountNumber",
+            identification: "08080021325698",
+            name: "ACME Inc",
+            secondaryIdentification: "0002"
+        },
+        type: "FRWriteDomesticStandingOrderDataInitiation",
+        frequency: "Paid on the 25th March, 24th June, 29th September and 25th December.",
+        firstPaymentDateTime: "2022-06-21T06:06:06.000Z",
+        finalPaymentDateTime: "2023-03-20T06:06:06.000Z",
+        firstPaymentAmount: {
+            amount: "165.88",
             currency: "GBP"
-          }
+        },
+        recurringPaymentAmount: {
+            amount: "165.88",
+            currency: "GBP"
+        },
+        finalPaymentAmount: {
+            amount: "165.88",
+            currency: "GBP"
         }
-      ]
-    }
-  ],
-  paymentReference: "Reference text",
-  intentType: "PAYMENT_DOMESTIC_STANDING_ORDERS_CONSENT"
+    },
+    accounts: [
+        {
+            id: "cdb062f6-daed-479a-8843-00f842926ef7",
+            userId: "7b78b560-6057-41c5-bf1f-1ed590b1c30b",
+            account: {
+                accountId: "cdb062f6-daed-479a-8843-00f842926ef7",
+                status: "Enabled",
+                statusUpdateDateTime: "2022-04-01T11:35:15.368Z",
+                currency: "GBP",
+                accountType: "Personal",
+                accountSubType: "CurrentAccount",
+                nickname: "UK Bills",
+                openingDate: "2022-03-31T11:35:15.368Z",
+                maturityDate: "2022-04-02T11:35:15.368Z",
+                accounts: [
+                    {
+                        schemeName: "UK.OBIE.SortCodeAccountNumber",
+                        identification: "30772183765717",
+                        name: "Will Smith account",
+                        secondaryIdentification: "66234289"
+                    }
+                ]
+            },
+            latestStatementId: "995af620-0f5c-4071-a7ca-6591038d12c4",
+            created: "2022-04-01T11:35:15.368Z",
+            balances: [
+                {
+                    accountId: "cdb062f6-daed-479a-8843-00f842926ef7",
+                    creditDebitIndicator: "Debit",
+                    type: "InterimAvailable",
+                    dateTime: "2022-04-01T11:35:15.373Z",
+                    amount: {
+                        amount: "1679.63",
+                        currency: "GBP"
+                    }
+                }
+            ]
+        }
+    ],
+    paymentReference: "Reference text",
+    intentType: "PAYMENT_DOMESTIC_STANDING_ORDERS_CONSENT"
 };

--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent-dev/mocks/debtorAccountProvided/international-standing-order-consent-details.js
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent-dev/mocks/debtorAccountProvided/international-standing-order-consent-details.js
@@ -1,80 +1,78 @@
 module.exports = {
-  type: "InternationalStandingOrderConsentDetails",
-  decisionApiUri: "/rcs/api/consent/decision/",
-  username: "psu4test",
-  userId: "24a3b7b8-b477-446b-8bec-69214d8a3582",
-  logo: "https://forgerock.com",
-  clientId: "aecab376-5c1d-4874-8549-475aa0eb68d2",
-  clientName: "TPP Test application",
-  serviceProviderName: "Forgerock Bank simulation config",
-  initiation: {
-    debtorAccount: {
-      schemeName: "UK.OBIE.SortCodeAccountNumber",
-      identification: "30772183765717",
-      name: "Will Smith account",
-      secondaryIdentification: "66234289"
-    },
-    creditorAccount: {
-      schemeName: "UK.OBIE.SortCodeAccountNumber",
-      identification: "08080021325698",
-      name: "ACME Inc",
-      secondaryIdentification: "0002"
-    }
-  },
-  internationalStandingOrder: {
-    type: "FRWriteInternationalStandingOrderDataInitiation",
-    frequency: "Every working day.",
-    firstPaymentDateTime: "2022-09-27T10:03:06.000Z",
-    finalPaymentDateTime: "2022-09-27T10:03:06.000Z",
-    instructedAmount: {
-      amount: "10.01",
-      currency: "GBP"
-    }
-  },
-  accounts: [
-    {
-      id: "cdb062f6-daed-479a-8843-00f842926ef7",
-      userId: "7b78b560-6057-41c5-bf1f-1ed590b1c30b",
-      account: {
-        accountId: "cdb062f6-daed-479a-8843-00f842926ef7",
-        status: "Enabled",
-        statusUpdateDateTime: "2022-04-01T11:35:15.368Z",
-        currency: "GBP",
-        accountType: "Personal",
-        accountSubType: "CurrentAccount",
-        nickname: "UK Bills",
-        openingDate: "2022-03-31T11:35:15.368Z",
-        maturityDate: "2022-04-02T11:35:15.368Z",
-        accounts: [
-          {
+    type: "InternationalStandingOrderConsentDetails",
+    decisionApiUri: "/rcs/api/consent/decision/",
+    username: "psu4test",
+    userId: "24a3b7b8-b477-446b-8bec-69214d8a3582",
+    logo: "https://forgerock.com",
+    clientId: "aecab376-5c1d-4874-8549-475aa0eb68d2",
+    clientName: "TPP Test application",
+    serviceProviderName: "Forgerock Bank simulation config",
+    initiation: {
+        debtorAccount: {
             schemeName: "UK.OBIE.SortCodeAccountNumber",
             identification: "30772183765717",
             name: "Will Smith account",
             secondaryIdentification: "66234289"
-          }
-        ]
-      },
-      latestStatementId: "995af620-0f5c-4071-a7ca-6591038d12c4",
-      created: "2022-04-01T11:35:15.368Z",
-      balances: [
-        {
-          accountId: "cdb062f6-daed-479a-8843-00f842926ef7",
-          creditDebitIndicator: "Debit",
-          type: "InterimAvailable",
-          dateTime: "2022-04-01T11:35:15.373Z",
-          amount: {
-            amount: "1679.63",
+        },
+        creditorAccount: {
+            schemeName: "UK.OBIE.SortCodeAccountNumber",
+            identification: "08080021325698",
+            name: "ACME Inc",
+            secondaryIdentification: "0002"
+        },
+        type: "FRWriteInternationalStandingOrderDataInitiation",
+        frequency: "Every working day.",
+        firstPaymentDateTime: "2022-09-27T10:03:06.000Z",
+        finalPaymentDateTime: "2022-09-27T10:03:06.000Z",
+        instructedAmount: {
+            amount: "10.01",
             currency: "GBP"
-          }
         }
-      ]
-    }
-  ],
-  charges: {
-    amount: "1.5",
-    currency: "GBP"
-  },
-  currencyOfTransfer: "USD",
-  paymentReference: "Ipsum Non Arcu Inc.",
-  intentType: "PAYMENT_INTERNATIONAL_STANDING_ORDERS_CONSENT"
+    },
+    accounts: [
+        {
+            id: "cdb062f6-daed-479a-8843-00f842926ef7",
+            userId: "7b78b560-6057-41c5-bf1f-1ed590b1c30b",
+            account: {
+                accountId: "cdb062f6-daed-479a-8843-00f842926ef7",
+                status: "Enabled",
+                statusUpdateDateTime: "2022-04-01T11:35:15.368Z",
+                currency: "GBP",
+                accountType: "Personal",
+                accountSubType: "CurrentAccount",
+                nickname: "UK Bills",
+                openingDate: "2022-03-31T11:35:15.368Z",
+                maturityDate: "2022-04-02T11:35:15.368Z",
+                accounts: [
+                    {
+                        schemeName: "UK.OBIE.SortCodeAccountNumber",
+                        identification: "30772183765717",
+                        name: "Will Smith account",
+                        secondaryIdentification: "66234289"
+                    }
+                ]
+            },
+            latestStatementId: "995af620-0f5c-4071-a7ca-6591038d12c4",
+            created: "2022-04-01T11:35:15.368Z",
+            balances: [
+                {
+                    accountId: "cdb062f6-daed-479a-8843-00f842926ef7",
+                    creditDebitIndicator: "Debit",
+                    type: "InterimAvailable",
+                    dateTime: "2022-04-01T11:35:15.373Z",
+                    amount: {
+                        amount: "1679.63",
+                        currency: "GBP"
+                    }
+                }
+            ]
+        }
+    ],
+    charges: {
+        amount: "1.5",
+        currency: "GBP"
+    },
+    currencyOfTransfer: "USD",
+    paymentReference: "Ipsum Non Arcu Inc.",
+    intentType: "PAYMENT_INTERNATIONAL_STANDING_ORDERS_CONSENT"
 }

--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent-dev/mocks/domestic-standing-order-response-details.js
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent-dev/mocks/domestic-standing-order-response-details.js
@@ -1,167 +1,155 @@
 module.exports = {
-  "type": "DomesticStandingOrderConsentDetails",
-  "decisionApiUri": "/rcs/api/consent/decision/",
-  "username": "psu4test",
-  "userId": "42edfd13-a642-47c1-b76c-684efe4e6449",
-  "logo": "https://forgerock.com",
-  "clientId": "63bce7d3-0c74-4188-9d24-88e3a69d3c80",
-  "clientName": "TPP Test application",
-  "serviceProviderName": "Forgerock Bank simulation config",
-  initiation: {
-    creditorAccount: {
-      schemeName: "UK.OBIE.SortCodeAccountNumber",
-      identification: "08080021325698",
-      name: "ACME Inc",
-      secondaryIdentification: "0002"
-    }
-  },
-  "standingOrder": {
-      "type": "FRWriteDomesticStandingOrderDataInitiation",
-      "frequency": "Paid on the 25th March, 24th June, 29th September and 25th December.",
-      "firstPaymentDateTime": "2022-06-21T06:06:06.000Z",
-      "finalPaymentDateTime": "2023-03-20T06:06:06.000Z",
-      "firstPaymentAmount": {
-          "amount": "165.88",
-          "currency": "GBP"
-      },
-      "recurringPaymentAmount": {
-          "amount": "165.88",
-          "currency": "GBP"
-      },
-      "finalPaymentAmount": {
-          "amount": "165.88",
-          "currency": "GBP"
-      }
-  },
-  "accounts": [
-      {
-          "id": "34974c6f-af48-44a6-beca-b8c31f978f63",
-          "userId": "42edfd13-a642-47c1-b76c-684efe4e6449",
-          "account": {
-              "accountId": "34974c6f-af48-44a6-beca-b8c31f978f63",
-              "status": "Enabled",
-              "statusUpdateDateTime": "2022-06-23T06:40:10.299Z",
-              "currency": "GBP",
-              "accountType": "Personal",
-              "accountSubType": "CurrentAccount",
-              "nickname": "UK Bills",
-              "openingDate": "2022-06-22T06:40:10.299Z",
-              "maturityDate": "2022-06-24T06:40:10.300Z",
-              "accounts": [
-                  {
-                      "schemeName": "UK.OBIE.SortCodeAccountNumber",
-                      "identification": "94737646552564",
-                      "name": "42edfd13-a642-47c1-b76c-684efe4e6449",
-                      "secondaryIdentification": "66809442"
-                  }
-              ],
-              "firstAccount": {
-                  "schemeName": "UK.OBIE.SortCodeAccountNumber",
-                  "identification": "94737646552564",
-                  "name": "42edfd13-a642-47c1-b76c-684efe4e6449",
-                  "secondaryIdentification": "66809442"
-              }
-          },
-          "latestStatementId": "fc3989e2-7b3f-4180-9989-e7647c254b8e",
-          "created": "2022-06-23T06:40:10.283Z",
-          "balances": [
-              {
-                  "accountId": "34974c6f-af48-44a6-beca-b8c31f978f63",
-                  "creditDebitIndicator": "Debit",
-                  "type": "InterimAvailable",
-                  "dateTime": "2022-06-23T06:40:10.512Z",
-                  "amount": {
-                      "amount": "10894.83",
-                      "currency": "GBP"
-                  }
-              }
-          ]
-      },
-      {
-          "id": "c5c827a2-56c1-4aa8-ae82-5dc27b04c4a8",
-          "userId": "42edfd13-a642-47c1-b76c-684efe4e6449",
-          "account": {
-              "accountId": "c5c827a2-56c1-4aa8-ae82-5dc27b04c4a8",
-              "status": "Enabled",
-              "statusUpdateDateTime": "2022-06-23T06:40:12.313Z",
-              "currency": "EUR",
-              "accountType": "Personal",
-              "accountSubType": "CurrentAccount",
-              "nickname": "FR Bills",
-              "openingDate": "2022-06-22T06:40:12.313Z",
-              "maturityDate": "2022-06-24T06:40:12.313Z",
-              "accounts": [
-                  {
-                      "schemeName": "UK.OBIE.SortCodeAccountNumber",
-                      "identification": "40359693847335",
-                      "name": "42edfd13-a642-47c1-b76c-684efe4e6449",
-                      "secondaryIdentification": "75177497"
-                  }
-              ],
-              "firstAccount": {
-                  "schemeName": "UK.OBIE.SortCodeAccountNumber",
-                  "identification": "40359693847335",
-                  "name": "42edfd13-a642-47c1-b76c-684efe4e6449",
-                  "secondaryIdentification": "75177497"
-              }
-          },
-          "latestStatementId": "7ca14403-ea56-4234-ae4f-c8aed3a066aa",
-          "created": "2022-06-23T06:40:12.313Z",
-          "balances": [
-              {
-                  "accountId": "c5c827a2-56c1-4aa8-ae82-5dc27b04c4a8",
-                  "creditDebitIndicator": "Debit",
-                  "type": "InterimAvailable",
-                  "dateTime": "2022-06-23T06:40:12.316Z",
-                  "amount": {
-                      "amount": "9098.35",
-                      "currency": "EUR"
-                  }
-              }
-          ]
-      },
-      {
-          "id": "dc2e014f-7b53-43ed-99fe-b8a656973162",
-          "userId": "42edfd13-a642-47c1-b76c-684efe4e6449",
-          "account": {
-              "accountId": "dc2e014f-7b53-43ed-99fe-b8a656973162",
-              "status": "Enabled",
-              "statusUpdateDateTime": "2022-06-23T06:40:13.496Z",
-              "currency": "GBP",
-              "accountType": "Personal",
-              "accountSubType": "CurrentAccount",
-              "nickname": "Household",
-              "openingDate": "2022-06-22T06:40:13.496Z",
-              "maturityDate": "2022-06-24T06:40:13.496Z",
-              "accounts": [
-                  {
-                      "schemeName": "UK.OBIE.SortCodeAccountNumber",
-                      "identification": "56542170356249",
-                      "name": "42edfd13-a642-47c1-b76c-684efe4e6449"
-                  }
-              ],
-              "firstAccount": {
-                  "schemeName": "UK.OBIE.SortCodeAccountNumber",
-                  "identification": "56542170356249",
-                  "name": "42edfd13-a642-47c1-b76c-684efe4e6449"
-              }
-          },
-          "latestStatementId": "16130bd0-2989-4aa9-b4e3-16c4350012d7",
-          "created": "2022-06-23T06:40:13.496Z",
-          "balances": [
-              {
-                  "accountId": "dc2e014f-7b53-43ed-99fe-b8a656973162",
-                  "creditDebitIndicator": "Debit",
-                  "type": "InterimAvailable",
-                  "dateTime": "2022-06-23T06:40:13.498Z",
-                  "amount": {
-                      "amount": "1074.87",
-                      "currency": "GBP"
-                  }
-              }
-          ]
-      }
-  ],
-  "paymentReference": "Reference text",
-  "intentType": "PAYMENT_DOMESTIC_STANDING_ORDERS_CONSENT"
+    "type": "DomesticStandingOrderConsentDetails",
+    "consentId": "PDSOC_d0f51320-9ba5-4f56-9949-f89afbc23d",
+    "decisionApiUri": "/rcs/api/consent/decision/",
+    "username": "psu4test",
+    "userId": "4737f9f9-fa0a-4159-bc61-7da31542e624",
+    "clientId": "88ca3111-fa9f-4ff3-a61d-6cd9961606c5",
+    "clientName": "SAPIG automating-testing",
+    "serviceProviderName": "Test Bank",
+    "accounts": [
+        {
+            "id": "01233243245676",
+            "userId": "4737f9f9-fa0a-4159-bc61-7da31542e624",
+            "account": {
+                "accountId": "01233243245676",
+                "status": "Enabled",
+                "statusUpdateDateTime": "2023-09-19T05:48:03.210Z",
+                "currency": "GBP",
+                "accountType": "Personal",
+                "accountSubType": "CurrentAccount",
+                "nickname": "UK Bills",
+                "openingDate": "2023-09-18T05:48:03.210Z",
+                "maturityDate": "2023-09-20T05:48:03.211Z",
+                "accounts": [
+                    {
+                        "schemeName": "UK.OBIE.SortCodeAccountNumber",
+                        "identification": "01233243245676",
+                        "name": "psu4test",
+                        "secondaryIdentification": "34277610"
+                    }
+                ]
+            },
+            "latestStatementId": "998aca23-f2f8-4a42-8e82-48fa571b50b3",
+            "created": "2023-09-19T05:48:03.128Z",
+            "updated": "2023-09-19T05:48:07.762Z",
+            "balances": [
+                {
+                    "accountId": "01233243245676",
+                    "creditDebitIndicator": "Debit",
+                    "type": "InterimAvailable",
+                    "dateTime": "2023-09-19T05:48:03.565Z",
+                    "amount": {
+                        "amount": "4713.45",
+                        "currency": "GBP"
+                    }
+                }
+            ]
+        },
+        {
+            "id": "01233254312390",
+            "userId": "4737f9f9-fa0a-4159-bc61-7da31542e624",
+            "account": {
+                "accountId": "01233254312390",
+                "status": "Enabled",
+                "statusUpdateDateTime": "2023-09-19T05:48:07.963Z",
+                "currency": "EUR",
+                "accountType": "Personal",
+                "accountSubType": "CurrentAccount",
+                "nickname": "FR Bills",
+                "openingDate": "2023-09-18T05:48:07.963Z",
+                "maturityDate": "2023-09-20T05:48:07.963Z",
+                "accounts": [
+                    {
+                        "schemeName": "UK.OBIE.SortCodeAccountNumber",
+                        "identification": "01233254312390",
+                        "name": "psu4test",
+                        "secondaryIdentification": "44398363"
+                    }
+                ]
+            },
+            "latestStatementId": "e5a0fdd1-b885-4e9e-94f9-648027faa7e6",
+            "created": "2023-09-19T05:48:07.963Z",
+            "updated": "2023-09-19T05:48:10.140Z",
+            "balances": [
+                {
+                    "accountId": "01233254312390",
+                    "creditDebitIndicator": "Debit",
+                    "type": "InterimAvailable",
+                    "dateTime": "2023-09-19T05:48:07.965Z",
+                    "amount": {
+                        "amount": "1391.86",
+                        "currency": "EUR"
+                    }
+                }
+            ]
+        },
+        {
+            "id": "33441230187862",
+            "userId": "4737f9f9-fa0a-4159-bc61-7da31542e624",
+            "account": {
+                "accountId": "33441230187862",
+                "status": "Enabled",
+                "statusUpdateDateTime": "2023-09-19T05:48:10.168Z",
+                "currency": "GBP",
+                "accountType": "Personal",
+                "accountSubType": "CurrentAccount",
+                "nickname": "Household",
+                "openingDate": "2023-09-18T05:48:10.168Z",
+                "maturityDate": "2023-09-20T05:48:10.168Z",
+                "accounts": [
+                    {
+                        "schemeName": "UK.OBIE.SortCodeAccountNumber",
+                        "identification": "33441230187862",
+                        "name": "psu4test"
+                    }
+                ]
+            },
+            "latestStatementId": "2179c1eb-cf73-4171-89b5-8dd7d6916141",
+            "created": "2023-09-19T05:48:10.168Z",
+            "updated": "2023-09-19T05:48:11.493Z",
+            "balances": [
+                {
+                    "accountId": "33441230187862",
+                    "creditDebitIndicator": "Debit",
+                    "type": "InterimAvailable",
+                    "dateTime": "2023-09-19T05:48:10.182Z",
+                    "amount": {
+                        "amount": "15087.65",
+                        "currency": "GBP"
+                    }
+                }
+            ]
+        }
+    ],
+    "initiation": {
+        "type": "FRWriteDomesticStandingOrderDataInitiation",
+        "frequency": "Paid on the 25th March, 24th June, 29th September and 25th December.",
+        "reference": "Reference text",
+        "firstPaymentDateTime": "2022-06-21T06:06:06.000Z",
+        "finalPaymentDateTime": "2023-03-20T06:06:06.000Z",
+        "firstPaymentAmount": {
+            "amount": "165.88",
+            "currency": "GBP"
+        },
+        "recurringPaymentAmount": {
+            "amount": "65",
+            "currency": "GBP"
+        },
+        "finalPaymentAmount": {
+            "amount": "525.83",
+            "currency": "GBP"
+        },
+        "creditorAccount": {
+            "schemeName": "UK.OBIE.SortCodeAccountNumber",
+            "identification": "08080021325698",
+            "name": "ACME Inc",
+            "secondaryIdentification": "0002"
+        }
+    },
+    "paymentReference": "Reference text",
+    "charges": {
+        "amount": "0"
+    },
+    "intentType": "PAYMENT_DOMESTIC_STANDING_ORDERS_CONSENT"
 };

--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent-dev/mocks/international-standing-order-consent-details.js
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent-dev/mocks/international-standing-order-consent-details.js
@@ -1,164 +1,181 @@
 module.exports = {
   "type": "InternationalStandingOrderConsentDetails",
+  "consentId": "PISOC_8f28f27e-5a19-4fa7-951d-9fd3ff5f24",
   "decisionApiUri": "/rcs/api/consent/decision/",
   "username": "psu4test",
-  "userId": "24a3b7b8-b477-446b-8bec-69214d8a3582",
-  "logo": "https://forgerock.com",
-  "clientId": "aecab376-5c1d-4874-8549-475aa0eb68d2",
-  "clientName": "TPP Test application",
-  "serviceProviderName": "Forgerock Bank simulation config",
-  initiation: {
-    creditorAccount: {
-      schemeName: "UK.OBIE.SortCodeAccountNumber",
-      identification: "08080021325698",
-      name: "ACME Inc",
-      secondaryIdentification: "0002"
-    }
-  },
-  "internationalStandingOrder": {
-    "type": "FRWriteInternationalStandingOrderDataInitiation",
-    "frequency": "Every working day.",
-    "firstPaymentDateTime": "2022-09-27T10:03:06.000Z",
-    "finalPaymentDateTime": "2022-09-27T10:03:06.000Z",
-    "instructedAmount": {
-      "amount": "10.01",
-      "currency": "GBP"
-    }
-  },
+  "userId": "4737f9f9-fa0a-4159-bc61-7da31542e624",
+  "clientId": "88ca3111-fa9f-4ff3-a61d-6cd9961606c5",
+  "clientName": "SAPIG automating-testing",
+  "serviceProviderName": "Test Bank",
   "accounts": [
     {
-      "id": "88420f4c-1cb3-48b9-9c70-9f377a8efcec",
-      "userId": "24a3b7b8-b477-446b-8bec-69214d8a3582",
+      "id": "01233243245676",
+      "userId": "4737f9f9-fa0a-4159-bc61-7da31542e624",
       "account": {
-        "accountId": "88420f4c-1cb3-48b9-9c70-9f377a8efcec",
+        "accountId": "01233243245676",
         "status": "Enabled",
-        "statusUpdateDateTime": "2022-09-29T06:59:11.000Z",
+        "statusUpdateDateTime": "2023-09-19T05:48:03.210Z",
         "currency": "GBP",
         "accountType": "Personal",
         "accountSubType": "CurrentAccount",
         "nickname": "UK Bills",
-        "openingDate": "2022-09-28T06:59:11.000Z",
-        "maturityDate": "2022-09-30T06:59:11.000Z",
-        "accounts": [
+        "openingDate": "2023-09-18T05:48:03.210Z",
+        "maturityDate": "2023-09-20T05:48:03.211Z",
+        "accounts":[
           {
             "schemeName": "UK.OBIE.SortCodeAccountNumber",
-            "identification": "33445235224228",
-            "name": "24a3b7b8-b477-446b-8bec-69214d8a3582",
-            "secondaryIdentification": "51171563"
+            "identification": "01233243245676",
+            "name": "psu4test",
+            "secondaryIdentification": "34277610"
           }
-        ],
-        "firstAccount": {
-          "schemeName": "UK.OBIE.SortCodeAccountNumber",
-          "identification": "33445235224228",
-          "name": "24a3b7b8-b477-446b-8bec-69214d8a3582",
-          "secondaryIdentification": "51171563"
-        }
+        ]
       },
-      "latestStatementId": "f1693471-2c7e-4fcf-8460-4b9b35f7f288",
-      "created": "2022-09-29T06:59:11.000Z",
+      "latestStatementId": "998aca23-f2f8-4a42-8e82-48fa571b50b3",
+      "created": "2023-09-19T05:48:03.128Z",
+      "updated": "2023-09-19T05:48:07.762Z",
       "balances": [
         {
-          "accountId": "88420f4c-1cb3-48b9-9c70-9f377a8efcec",
+          "accountId": "01233243245676",
           "creditDebitIndicator": "Debit",
           "type": "InterimAvailable",
-          "dateTime": "2022-09-29T06:59:12.000Z",
+          "dateTime": "2023-09-19T05:48:03.565Z",
           "amount": {
-            "amount": "2435.91",
+            "amount": "4713.45",
             "currency": "GBP"
           }
         }
       ]
     },
     {
-      "id": "7cac111f-0361-44cf-b29d-b28f65e37dae",
-      "userId": "24a3b7b8-b477-446b-8bec-69214d8a3582",
+      "id": "01233254312390",
+      "userId": "4737f9f9-fa0a-4159-bc61-7da31542e624",
       "account": {
-        "accountId": "7cac111f-0361-44cf-b29d-b28f65e37dae",
+        "accountId": "01233254312390",
         "status": "Enabled",
-        "statusUpdateDateTime": "2022-09-29T06:59:13.000Z",
+        "statusUpdateDateTime": "2023-09-19T05:48:07.963Z",
         "currency": "EUR",
         "accountType": "Personal",
         "accountSubType": "CurrentAccount",
         "nickname": "FR Bills",
-        "openingDate": "2022-09-28T06:59:13.000Z",
-        "maturityDate": "2022-09-30T06:59:13.000Z",
+        "openingDate": "2023-09-18T05:48:07.963Z",
+        "maturityDate": "2023-09-20T05:48:07.963Z",
         "accounts": [
           {
             "schemeName": "UK.OBIE.SortCodeAccountNumber",
-            "identification": "77323579641141",
-            "name": "24a3b7b8-b477-446b-8bec-69214d8a3582",
-            "secondaryIdentification": "28664857"
+            "identification": "01233254312390",
+            "name": "psu4test",
+            "secondaryIdentification": "44398363"
           }
-        ],
-        "firstAccount": {
-          "schemeName": "UK.OBIE.SortCodeAccountNumber",
-          "identification": "77323579641141",
-          "name": "24a3b7b8-b477-446b-8bec-69214d8a3582",
-          "secondaryIdentification": "28664857"
-        }
+        ]
       },
-      "latestStatementId": "3293220b-eb77-4dd9-9222-f631a09759ec",
-      "created": "2022-09-29T06:59:13.000Z",
+      "latestStatementId": "e5a0fdd1-b885-4e9e-94f9-648027faa7e6",
+      "created": "2023-09-19T05:48:07.963Z",
+      "updated": "2023-09-19T05:48:10.140Z",
       "balances": [
         {
-          "accountId": "7cac111f-0361-44cf-b29d-b28f65e37dae",
+          "accountId": "01233254312390",
           "creditDebitIndicator": "Debit",
           "type": "InterimAvailable",
-          "dateTime": "2022-09-29T06:59:13.000Z",
+          "dateTime": "2023-09-19T05:48:07.965Z",
           "amount": {
-            "amount": "8104.69",
+            "amount": "1391.86",
             "currency": "EUR"
           }
         }
       ]
     },
     {
-      "id": "e67445c0-3138-4362-a9af-6a16114d9097",
-      "userId": "24a3b7b8-b477-446b-8bec-69214d8a3582",
+      "id": "33441230187862",
+      "userId": "4737f9f9-fa0a-4159-bc61-7da31542e624",
       "account": {
-        "accountId": "e67445c0-3138-4362-a9af-6a16114d9097",
+        "accountId": "33441230187862",
         "status": "Enabled",
-        "statusUpdateDateTime": "2022-09-29T06:59:14.000Z",
+        "statusUpdateDateTime": "2023-09-19T05:48:10.168Z",
         "currency": "GBP",
         "accountType": "Personal",
         "accountSubType": "CurrentAccount",
         "nickname": "Household",
-        "openingDate": "2022-09-28T06:59:14.000Z",
-        "maturityDate": "2022-09-30T06:59:14.000Z",
+        "openingDate": "2023-09-18T05:48:10.168Z",
+        "maturityDate": "2023-09-20T05:48:10.168Z",
         "accounts": [
           {
             "schemeName": "UK.OBIE.SortCodeAccountNumber",
-            "identification": "98246566821200",
-            "name": "24a3b7b8-b477-446b-8bec-69214d8a3582"
+            "identification": "33441230187862",
+            "name": "psu4test"
           }
-        ],
-        "firstAccount": {
-          "schemeName": "UK.OBIE.SortCodeAccountNumber",
-          "identification": "98246566821200",
-          "name": "24a3b7b8-b477-446b-8bec-69214d8a3582"
-        }
+        ]
       },
-      "latestStatementId": "a469c220-9d76-4467-bd8d-2621d09c915e",
-      "created": "2022-09-29T06:59:14.000Z",
+      "latestStatementId": "2179c1eb-cf73-4171-89b5-8dd7d6916141",
+      "created": "2023-09-19T05:48:10.168Z",
+      "updated": "2023-09-19T05:48:11.493Z",
       "balances": [
         {
-          "accountId": "e67445c0-3138-4362-a9af-6a16114d9097",
+          "accountId": "33441230187862",
           "creditDebitIndicator": "Debit",
           "type": "InterimAvailable",
-          "dateTime": "2022-09-29T06:59:14.000Z",
+          "dateTime": "2023-09-19T05:48:10.182Z",
           "amount": {
-            "amount": "7956.70",
+            "amount": "15087.65",
             "currency": "GBP"
           }
         }
       ]
     }
   ],
+  "initiation": {
+    "type": "FRWriteInternationalStandingOrderDataInitiation",
+    "frequency": "Every working day.",
+    "reference": "Ipsum Non Arcu Inc.",
+    "numberOfPayments": "1",
+    "firstPaymentDateTime": "2022-09-27T10:03:06.000Z",
+    "finalPaymentDateTime": "2022-09-27T10:03:06.000Z",
+    "purpose": "CDCD",
+    "extendedPurpose": "Extended purpose",
+    "chargeBearer": "SHARED",
+    "currencyOfTransfer": "USD",
+    "destinationCountryCode": "GB",
+    "instructedAmount": {
+      "amount": "10.01",
+      "currency": "GBP"
+    },
+    "creditor": {
+      "name": "Creditor Name",
+      "postalAddress": {
+        "addressType": "RESIDENTIAL",
+        "streetName": "The Mall",
+        "buildingNumber": "1",
+        "postCode": "WC1 1AB",
+        "townName": "London",
+        "country": "UK"
+      }
+    },
+    "creditorAgent": {
+      "schemeName": "UK.OBIE.SortCodeAccountNumber",
+      "identification": "40400411270111",
+      "name": "Creditor Agent Name",
+      "postalAddress": {
+        "addressType": "RESIDENTIAL",
+        "streetName": "The Mall",
+        "buildingNumber": "1",
+        "postCode": "WC1 1AB",
+        "townName": "London",
+        "country": "UK"
+      }
+    },
+    "creditorAccount": {
+      "schemeName": "UK.OBIE.SortCodeAccountNumber",
+      "identification": "90611424625555",
+      "name": "Mr Steven Morrissey",
+      "secondaryIdentification": "44"
+    },
+    "supplementaryData": {
+      "data": "{}"
+    }
+  },
   "charges": {
-    "amount": "1.5",
-    "currency": "GBP"
+    "amount": "0"
   },
   "currencyOfTransfer": "USD",
   "paymentReference": "Ipsum Non Arcu Inc.",
   "intentType": "PAYMENT_INTERNATIONAL_STANDING_ORDERS_CONSENT"
-}
+};

--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/domestic-standing-order/domestic-standing-order.component.ts
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/domestic-standing-order/domestic-standing-order.component.ts
@@ -85,8 +85,8 @@ export class DomesticStandingOrderComponent implements OnInit {
       }
     });
     if (
-      _get(this.response, 'standingOrder.firstPaymentDateTime') &&
-      _get(this.response, 'standingOrder.firstPaymentAmount')
+      _get(this.response, 'initiation.firstPaymentDateTime') &&
+      _get(this.response, 'initiation.firstPaymentAmount')
     ) {
       this.items.push({
         type: ItemType.FIRST_PAYMENT,
@@ -94,28 +94,28 @@ export class DomesticStandingOrderComponent implements OnInit {
           firstPaymentLabel: 'CONSENT.DOMESTIC-STANDING-ORDER.FIRST_PAYMENT',
           firstPaymentDateLabel: 'CONSENT.DOMESTIC-STANDING-ORDER.FIRST_PAYMENT_DATE',
           firstPaymentAmountLabel: 'CONSENT.DOMESTIC-STANDING-ORDER.FIRST_PAYMENT_AMOUNT',
-          firstPaymentDate: this.response.standingOrder.firstPaymentDateTime,
-          firstPaymentAmount: this.response.standingOrder.firstPaymentAmount,
+          firstPaymentDate: this.response.initiation.firstPaymentDateTime,
+          firstPaymentAmount: this.response.initiation.firstPaymentAmount,
           cssClass: 'domestic-standing-order-FirstPayment'
         }
       });
     }
-    if (_get(this.response, 'standingOrder.recurringPaymentAmount') && _get(this.response, 'standingOrder.frequency')) {
+    if (_get(this.response, 'initiation.recurringPaymentAmount') && _get(this.response, 'initiation.frequency')) {
       this.items.push({
         type: ItemType.RECURRING_PAYMENT,
         payload: {
           nextPaymentLabel: 'CONSENT.DOMESTIC-STANDING-ORDER.RECURRING_PAYMENT',
           nextPaymentAmountLabel: 'CONSENT.DOMESTIC-STANDING-ORDER.RECURRING_PAYMENT_AMOUNT',
           frequencyLabel: 'CONSENT.DOMESTIC-STANDING-ORDER.FREQ',
-          nextPaymentAmount: this.response.standingOrder.recurringPaymentAmount,
-          frequency: this.response.standingOrder.frequency,
+          nextPaymentAmount: this.response.initiation.recurringPaymentAmount,
+          frequency: this.response.initiation.frequency,
           cssClass: 'domestic-standing-order-NextPayment'
         }
       });
     }
     if (
-      _get(this.response, 'standingOrder.finalPaymentDateTime') &&
-      _get(this.response, 'standingOrder.finalPaymentAmount')
+      _get(this.response, 'initiation.finalPaymentDateTime') &&
+      _get(this.response, 'initiation.finalPaymentAmount')
     ) {
       this.items.push({
         type: ItemType.FINAL_PAYMENT,
@@ -123,8 +123,8 @@ export class DomesticStandingOrderComponent implements OnInit {
           finalPaymentLabel: 'CONSENT.DOMESTIC-STANDING-ORDER.FINAL_PAYMENT',
           finalPaymentDateLabel: 'CONSENT.DOMESTIC-STANDING-ORDER.FINAL_PAYMENT_DATE',
           finalPaymentAmountLabel: 'CONSENT.DOMESTIC-STANDING-ORDER.FINAL_PAYMENT_AMOUNT',
-          finalPaymentDate: this.response.standingOrder.finalPaymentDateTime,
-          finalPaymentAmount: this.response.standingOrder.finalPaymentAmount,
+          finalPaymentDate: this.response.initiation.finalPaymentDateTime,
+          finalPaymentAmount: this.response.initiation.finalPaymentAmount,
           cssClass: 'domestic-standing-order-FinalPayment'
         }
       });

--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/international-standing-order/international-standing-order.component.ts
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/international-standing-order/international-standing-order.component.ts
@@ -86,8 +86,8 @@ export class InternationalStandingOrderComponent implements OnInit {
     });
 
     if (
-      _get(this.response, 'internationalStandingOrder.firstPaymentDateTime') &&
-      _get(this.response, 'internationalStandingOrder.instructedAmount')
+      _get(this.response, 'initiation.firstPaymentDateTime') &&
+      _get(this.response, 'initiation.instructedAmount')
     ) {
       this.items.push({
         type: ItemType.FIRST_PAYMENT,
@@ -95,29 +95,29 @@ export class InternationalStandingOrderComponent implements OnInit {
           firstPaymentLabel: 'CONSENT.INTERNATIONAL-STANDING-ORDER.FIRST_PAYMENT',
           firstPaymentDateLabel: 'CONSENT.INTERNATIONAL-STANDING-ORDER.DATE',
           firstPaymentAmountLabel: 'CONSENT.INTERNATIONAL-STANDING-ORDER.AMOUNT',
-          firstPaymentDate: this.response.internationalStandingOrder.firstPaymentDateTime,
-          firstPaymentAmount: this.response.internationalStandingOrder.instructedAmount,
+          firstPaymentDate: this.response.initiation.firstPaymentDateTime,
+          firstPaymentAmount: this.response.initiation.instructedAmount,
           cssClass: 'file-payment-FirstPayment'
         }
       });
     }
-    if (_get(this.response, 'internationalStandingOrder.instructedAmount') &&
-        _get(this.response, 'internationalStandingOrder.frequency')) {
+    if (_get(this.response, 'initiation.instructedAmount') &&
+        _get(this.response, 'initiation.frequency')) {
       this.items.push({
         type: ItemType.RECURRING_PAYMENT,
         payload: {
           nextPaymentLabel: 'CONSENT.INTERNATIONAL-STANDING-ORDER.RECURRING_PAYMENT',
           nextPaymentAmountLabel: 'CONSENT.INTERNATIONAL-STANDING-ORDER.AMOUNT',
           frequencyLabel: 'CONSENT.INTERNATIONAL-STANDING-ORDER.FREQ',
-          nextPaymentAmount: this.response.internationalStandingOrder.instructedAmount,
-          frequency: this.response.internationalStandingOrder.frequency,
+          nextPaymentAmount: this.response.initiation.instructedAmount,
+          frequency: this.response.initiation.frequency,
           cssClass: 'file-payment-NextPayment'
         }
       });
     }
     if (
-      _get(this.response, 'internationalStandingOrder.finalPaymentDateTime') &&
-      _get(this.response, 'internationalStandingOrder.instructedAmount')
+      _get(this.response, 'initiation.finalPaymentDateTime') &&
+      _get(this.response, 'initiation.instructedAmount')
     ) {
       this.items.push({
         type: ItemType.FINAL_PAYMENT,
@@ -125,8 +125,8 @@ export class InternationalStandingOrderComponent implements OnInit {
           finalPaymentLabel: 'CONSENT.INTERNATIONAL-STANDING-ORDER.FINAL_PAYMENT',
           finalPaymentDateLabel: 'CONSENT.INTERNATIONAL-STANDING-ORDER.DATE',
           finalPaymentAmountLabel: 'CONSENT.INTERNATIONAL-STANDING-ORDER.AMOUNT',
-          finalPaymentDate: this.response.internationalStandingOrder.finalPaymentDateTime,
-          finalPaymentAmount: this.response.internationalStandingOrder.instructedAmount,
+          finalPaymentDate: this.response.initiation.finalPaymentDateTime,
+          finalPaymentAmount: this.response.initiation.instructedAmount,
           cssClass: 'file-payment-FinalPayment'
         }
       });

--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/types/api.ts
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/types/api.ts
@@ -36,22 +36,6 @@ export module ApiResponses {
     account: OBAccount2;
     initiation: Initiation;
     controlParameters?: ControlParameters; // vrp payment
-    standingOrder?: {
-      frequency: string;
-      reference: string;
-      firstPaymentDateTime: string;
-      firstPaymentAmount: OBActiveOrHistoricCurrencyAndAmount;
-      recurringPaymentDateTime: string;
-      recurringPaymentAmount: OBActiveOrHistoricCurrencyAndAmount;
-      finalPaymentDateTime: string;
-      finalPaymentAmount: OBActiveOrHistoricCurrencyAndAmount;
-    };
-    internationalStandingOrder?: {
-      frequency: string;
-      firstPaymentDateTime: string;
-      instructedAmount: OBActiveOrHistoricCurrencyAndAmount;
-      finalPaymentDateTime: string;
-    };
     filePayment?: {
       fileReference: string;
       numberOfTransactions: string;

--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/types/api.ts
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/types/api.ts
@@ -121,6 +121,15 @@ export class Initiation {
   debtorAccount?: OBCashAccount3;
   creditorAccount?: OBCashAccount3;
   remittanceInformation?: RemittanceInformation;
+  frequency?: string;
+  reference?: string;
+  firstPaymentDateTime?: string;
+  firstPaymentAmount?: OBActiveOrHistoricCurrencyAndAmount;
+  recurringPaymentDateTime?: string;
+  recurringPaymentAmount?: OBActiveOrHistoricCurrencyAndAmount;
+  finalPaymentDateTime?: string;
+  finalPaymentAmount?: OBActiveOrHistoricCurrencyAndAmount;
+  instructedAmount?: OBActiveOrHistoricCurrencyAndAmount;
 }
 
 export class RemittanceInformation {


### PR DESCRIPTION
- Fixed missed standing order display data
- Updated mock test for standing orders (domestic and international payments)

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1026