### PR TITLE
987: Artifact Registry Migration

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -17,22 +17,24 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: google-github-actions/auth@v0
+      - name: Auth to GCP  
+        uses: google-github-actions/auth@v2
         with:
-          credentials_json: ${{ secrets.GCR_CREDENTIALS_JSON }}
+          credentials_json: ${{ secrets.DEV_GAR_KEY }}
 
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v0
+        uses: google-github-actions/setup-gcloud@v1.1.1
 
         # Configure docker to use the gcloud command-line tool as a credential helper
-      - run: |
-          gcloud auth configure-docker
+      - name: Auth Docker
+        run: |
+          gcloud auth configure-docker europe-west4-docker.pkg.dev
 
       - name: test
         run: |
           make docker tag=${{ env.GIT_SHA_SHORT }}
-          docker tag eu.gcr.io/${{ secrets.GCR_DEV_REPO }}/securebanking/ui/${{ env.SERVICE_NAME }}:${{ env.GIT_SHA_SHORT }} eu.gcr.io/${{ secrets.GCR_DEV_REPO }}/securebanking/ui/${{ env.SERVICE_NAME }}:latest
-          docker push --all-tags eu.gcr.io/${{ secrets.GCR_DEV_REPO }}/securebanking/ui/rcs
+          docker tag ${{ vars.GAR_DEV_REPO }}/securebanking/ui/${{ env.SERVICE_NAME }}:${{ env.GIT_SHA_SHORT }} ${{ vars.GAR_DEV_REPO }}/securebanking/ui/${{ env.SERVICE_NAME }}:latest
+          docker push ${{ vars.GAR_DEV_REPO }}/securebanking/ui/${{ env.SERVICE_NAME }} --all-tags
 
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -54,15 +54,17 @@ jobs:
         run: |
           npm run test
       # https://github.com/google-github-actions/setup-gcloud#authorization
-      - uses: google-github-actions/auth@v0
+      - name: Auth to GCP  
+        uses: google-github-actions/auth@v2
         with:
-          credentials_json: ${{ secrets.GCR_CREDENTIALS_JSON }}
+          credentials_json: ${{ secrets.DEV_GAR_KEY }}
 
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v0
+        uses: google-github-actions/setup-gcloud@v1.1.1
 
-      - run: |
-          gcloud auth configure-docker
+      - name: Auth Docker
+        run: |
+          gcloud auth configure-docker europe-west4-docker.pkg.dev
 
       - name: Build Docker Image
         run: |

--- a/.github/workflows/release-rcs.yml
+++ b/.github/workflows/release-rcs.yml
@@ -40,8 +40,8 @@ jobs:
       SERVICE_NAME: ui/rcs
       with_maven: false
     secrets:
-      GCR_CREDENTIALS_JSON: ${{ secrets.GCR_CREDENTIALS_JSON }}
-      GCR_RELEASE_REPO: ${{ secrets.GCR_RELEASE_REPO }}
+      GCR_credentials_json: ${{ secrets.DEV_GAR_KEY }}
+      GCR_RELEASE_REPO: ${{ vars.GAR_RELEASE_REPO }}
 
   release_helm:
     name: Call publish helm

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 name := securebanking-ui
 service := rcs
-repo := sbat-gcr-develop
+repo := europe-west4-docker.pkg.dev/sbat-gcr-develop/sapig-docker-artifact
 tag  := latest
 helm_repo := forgerock-helm/secure-api-gateway/securebanking-ui/
 shouldBePushed = true
@@ -24,16 +24,16 @@ update_versions:
 docker:
 # info section
 ifeq ($(shouldBePushed), true)
-	$(info The service=${service} image WILL BE PUSHED to repository eu.gcr.io/${repo}/securebanking/ui/${service}:${tag})
+	$(info The service=${service} image WILL BE PUSHED to repository ${repo}/securebanking/ui/${service}:${tag})
 else
-	$(info The service=${service} image WILL NOT BE PUSHED to repository eu.gcr.io/${repo}/securebanking/ui/${service}:${tag})
+	$(info The service=${service} image WILL NOT BE PUSHED to repository ${repo}/securebanking/ui/${service}:${tag})
 endif
 # build section
 	cd secure-api-gateway-ob-uk-ui-${service} && \
-	docker build -t eu.gcr.io/${repo}/securebanking/ui/${service}:${tag} -f projects/${service}/docker/Dockerfile .
+	docker build -t ${repo}/securebanking/ui/${service}:${tag} -f projects/${service}/docker/Dockerfile .
 # push section with condition (default true)
 ifeq ($(shouldBePushed), true)
-	docker push eu.gcr.io/${repo}/securebanking/ui/${service}:${tag}
+	docker push ${repo}/securebanking/ui/${service}:${tag}
 endif
 
 # Helm target

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   securebanking-config-server:
     container_name: securebanking-config-server
     hostname: securebanking-config-server
-    image: eu.gcr.io/sbat-gcr-develop/securebanking/securebanking-spring-config-server:latest
+    image: europe-west4-docker.pkg.dev/sbat-gcr-develop/sapig-docker-artifact/securebanking/securebanking-spring-config-server:latest
     environment:
       - CONFIG_GIT_IGNORE_LOCAL_SSH=true
       - GIT_CONFIG_SSH_KEY=${GIT_SSH_KEY}
@@ -15,7 +15,7 @@ services:
   rcs-service:
     container_name: rcs-service
     hostname: rcs
-    image: eu.gcr.io/sbat-gcr-develop/securebanking/securebanking-openbanking-uk-rcs:latest
+    image: europe-west4-docker.pkg.dev/sbat-gcr-develop/sapig-docker-artifact/securebanking/securebanking-openbanking-uk-rcs:latest
     ports:
       - 8080:8080
       - 9095:9095

--- a/secure-api-gateway-ob-uk-ui-rcs/README.md
+++ b/secure-api-gateway-ob-uk-ui-rcs/README.md
@@ -37,11 +37,11 @@ npm run test
 ### Build
 ```bash
 # Build
-docker build -t eu.gcr.io/sbat-gcr-develop/securebanking/ui/rcs:local -f projects/rcs/docker/Dockerfile .
+docker build -t europe-west4-docker.pkg.dev/sbat-gcr-develop/sapig-docker-artifact/securebanking/ui/rcs:local -f projects/rcs/docker/Dockerfile .
 ```
 ### Run
 > Update the values on `./projects/rcs/docker/local.env` if necessary before `docker run`
 ```shell
-docker run -p 80:80 --env-file ./projects/rcs/docker/local.env eu.gcr.io/sbat-gcr-develop/securebanking/ui/rcs:local
+docker run -p 80:80 --env-file ./projects/rcs/docker/local.env europe-west4-docker.pkg.dev/sbat-gcr-develop/sapig-docker-artifact/securebanking/ui/rcs:local
 ```
 Open http://localhost


### PR DESCRIPTION
- Change any pipelines to push to the new Artifact Registry
- Change any pipelines / packages that pull images to use the new Artifact Registry
- Change Auth to GCP pipeline command to use V2 as V0 is deprecated

Issue:
- https://github.com/SecureApiGateway/SecureApiGateway/issues/987
- https://github.com/SecureApiGateway/SecureApiGateway/issues/1202