### PR TITLE
1245: Removing trailing slash from Consent API URIs

### DIFF
--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent-dev/mocks/account-access-consent-details.js
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent-dev/mocks/account-access-consent-details.js
@@ -1,6 +1,6 @@
 module.exports = {
     "type": "AccountsConsentDetails",
-    "decisionApiUri": "/rcs/api/consent/decision/",
+    "decisionApiUri": "/rcs/api/consent/decision",
     "username": "psu4test",
     "userId": "fc99f546-8507-428b-88f2-1d78860a0881",
     "logo": "https://forgerock.com",

--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent-dev/mocks/customer-info-details.js
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent-dev/mocks/customer-info-details.js
@@ -1,7 +1,7 @@
 module.exports = {
   type: "CustomerInfoConsentDetails",
   "consentId": "CIC_a337e1a0-53ab-478b-b59a-1d68d5f07244",
-  decisionApiUri: "/rcs/api/consent/decision/",
+  decisionApiUri: "/rcs/api/consent/decision",
   username: "bab001",
   userId: "61d9f601-4003-44b6-ab47-5b5eb83f85fb",
   clientId: "5f996ff6-1b44-47a3-9651-0cc5946aeca7",

--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent-dev/mocks/debtorAccountProvided/domestic-payment-consent-details.js
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent-dev/mocks/debtorAccountProvided/domestic-payment-consent-details.js
@@ -1,6 +1,6 @@
 module.exports = {
   type: "DomesticPaymentsConsentDetails",
-  decisionApiUri: "/rcs/api/consent/decision/",
+  decisionApiUri: "/rcs/api/consent/decision",
   username: "psu4test",
   userId: "7b78b560-6057-41c5-bf1f-1ed590b1c30b",
   logo: "https://forgerock.com",

--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent-dev/mocks/debtorAccountProvided/domestic-scheduled-payment-response-details.js
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent-dev/mocks/debtorAccountProvided/domestic-scheduled-payment-response-details.js
@@ -1,6 +1,6 @@
 module.exports = {
   type: "DomesticScheduledPaymentConsentDetails",
-  decisionApiUri: "/rcs/api/consent/decision/",
+  decisionApiUri: "/rcs/api/consent/decision",
   username: "psu4test",
   userId: "737742f2-01e4-4efa-a131-77e6526f98d2",
   logo: "https://forgerock.com",

--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent-dev/mocks/debtorAccountProvided/domestic-standing-order-response-details.js
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent-dev/mocks/debtorAccountProvided/domestic-standing-order-response-details.js
@@ -1,6 +1,6 @@
 module.exports = {
     type: "DomesticStandingOrderConsentDetails",
-    decisionApiUri: "/rcs/api/consent/decision/",
+    decisionApiUri: "/rcs/api/consent/decision",
     username: "psu4test",
     userId: "42edfd13-a642-47c1-b76c-684efe4e6449",
     logo: "https://forgerock.com",

--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent-dev/mocks/debtorAccountProvided/file-payment-consent-details.js
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent-dev/mocks/debtorAccountProvided/file-payment-consent-details.js
@@ -1,6 +1,6 @@
 module.exports = {
   type: "FilePaymentConsentDetails",
-  decisionApiUri: "/rcs/api/consent/decision/",
+  decisionApiUri: "/rcs/api/consent/decision",
   username: "testUserName",
   userId: "c7303aee-2ff1-44b5-b21f-a7a3aaf39271",
   logo: "https://www.vhv.rs/dpng/d/455-4556963_warner-bros-logo-warner-brothers-logo-png-transparent.png",

--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent-dev/mocks/debtorAccountProvided/international-payment-consent-details.js
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent-dev/mocks/debtorAccountProvided/international-payment-consent-details.js
@@ -1,6 +1,6 @@
 module.exports = {
   type: "InternationalPaymentConsentDetails",
-  decisionApiUri: "/rcs/api/consent/decision/",
+  decisionApiUri: "/rcs/api/consent/decision",
   username: "psu4test",
   userId: "86228a9d-812d-4a15-a2f7-6a45488e593b",
   logo: "https://forgerock.com",

--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent-dev/mocks/debtorAccountProvided/international-scheduled-payment-consent-details.js
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent-dev/mocks/debtorAccountProvided/international-scheduled-payment-consent-details.js
@@ -1,6 +1,6 @@
 module.exports = {
   type: "InternationalScheduledPaymentConsentDetails",
-  decisionApiUri: "/rcs/api/consent/decision/",
+  decisionApiUri: "/rcs/api/consent/decision",
   username: "psu4test",
   userId: "86228a9d-812d-4a15-a2f7-6a45488e593b",
   logo: "https://forgerock.com",

--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent-dev/mocks/debtorAccountProvided/international-standing-order-consent-details.js
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent-dev/mocks/debtorAccountProvided/international-standing-order-consent-details.js
@@ -1,6 +1,6 @@
 module.exports = {
     type: "InternationalStandingOrderConsentDetails",
-    decisionApiUri: "/rcs/api/consent/decision/",
+    decisionApiUri: "/rcs/api/consent/decision",
     username: "psu4test",
     userId: "24a3b7b8-b477-446b-8bec-69214d8a3582",
     logo: "https://forgerock.com",

--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent-dev/mocks/debtorAccountProvided/vrp-payment-consent-details.js
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent-dev/mocks/debtorAccountProvided/vrp-payment-consent-details.js
@@ -1,6 +1,6 @@
 module.exports = {
   type: "DomesticVrpPaymentConsentDetails",
-  decisionApiUri: "/rcs/api/consent/decision/",
+  decisionApiUri: "/rcs/api/consent/decision",
   username: "testUserName",
   userId: "c7303aee-2ff1-44b5-b21f-a7a3aaf39271",
   logo: "https://www.vhv.rs/dpng/d/455-4556963_warner-bros-logo-warner-brothers-logo-png-transparent.png",

--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent-dev/mocks/domestic-payment-consent-details.js
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent-dev/mocks/domestic-payment-consent-details.js
@@ -1,6 +1,6 @@
 module.exports = {
   type: "DomesticPaymentsConsentDetails",
-  decisionApiUri: "/rcs/api/consent/decision/",
+  decisionApiUri: "/rcs/api/consent/decision",
   username: "psu4test",
   userId: "7b78b560-6057-41c5-bf1f-1ed590b1c30b",
   logo: "https://forgerock.com",

--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent-dev/mocks/domestic-scheduled-payment-response-details.js
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent-dev/mocks/domestic-scheduled-payment-response-details.js
@@ -1,6 +1,6 @@
 module.exports = {
   "type": "DomesticScheduledPaymentConsentDetails",
-  "decisionApiUri": "/rcs/api/consent/decision/",
+  "decisionApiUri": "/rcs/api/consent/decision",
   "username": "psu4test",
   "userId": "737742f2-01e4-4efa-a131-77e6526f98d2",
   "logo": "https://forgerock.com",

--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent-dev/mocks/domestic-standing-order-response-details.js
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent-dev/mocks/domestic-standing-order-response-details.js
@@ -1,7 +1,7 @@
 module.exports = {
     "type": "DomesticStandingOrderConsentDetails",
     "consentId": "PDSOC_d0f51320-9ba5-4f56-9949-f89afbc23d",
-    "decisionApiUri": "/rcs/api/consent/decision/",
+    "decisionApiUri": "/rcs/api/consent/decision",
     "username": "psu4test",
     "userId": "4737f9f9-fa0a-4159-bc61-7da31542e624",
     "clientId": "88ca3111-fa9f-4ff3-a61d-6cd9961606c5",

--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent-dev/mocks/file-payment-consent-details.js
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent-dev/mocks/file-payment-consent-details.js
@@ -1,6 +1,6 @@
 module.exports = {
   "type": "FilePaymentConsentDetails",
-  "decisionApiUri": "/rcs/api/consent/decision/",
+  "decisionApiUri": "/rcs/api/consent/decision",
   "username": "testUserName",
   "userId": "c7303aee-2ff1-44b5-b21f-a7a3aaf39271",
   "logo": "https://www.vhv.rs/dpng/d/455-4556963_warner-bros-logo-warner-brothers-logo-png-transparent.png",

--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent-dev/mocks/funds-confirmation-consent-details.js
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent-dev/mocks/funds-confirmation-consent-details.js
@@ -1,7 +1,7 @@
 module.exports = {
   "type": "FundsConfirmationConsentDetails",
   "consentId": "FCC_67e60d61-2cd4-4e9c-a473-8680b8e7c309",
-  "decisionApiUri": "/rcs/api/consent/decision/",
+  "decisionApiUri": "/rcs/api/consent/decision",
   "username": "psu4test",
   "userId": "4737f9f9-fa0a-4159-bc61-7da31542e624",
   "clientId": "ce058417-bedc-444e-ba3d-fb793423ad27",

--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent-dev/mocks/international-payment-consent-details.js
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent-dev/mocks/international-payment-consent-details.js
@@ -1,7 +1,7 @@
 module.exports = {
     "type": "InternationalPaymentConsentDetails",
     "consentId": "PIC_2d4317b5-69aa-44a6-9fc8-aacb57b1f832",
-    "decisionApiUri": "/rcs/api/consent/decision/",
+    "decisionApiUri": "/rcs/api/consent/decision",
     "username": "psu4test",
     "userId": "4737f9f9-fa0a-4159-bc61-7da31542e624",
     "clientId": "71ca6faf-08a6-4db8-a70a-0a086900f606",

--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent-dev/mocks/international-scheduled-payment-consent-details.js
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent-dev/mocks/international-scheduled-payment-consent-details.js
@@ -1,7 +1,7 @@
 module.exports = {
     "type": "InternationalScheduledPaymentConsentDetails",
     "consentId": "PISC_24f3d6b2-764b-4d58-91d2-ea40c35264e",
-    "decisionApiUri": "/rcs/api/consent/decision/",
+    "decisionApiUri": "/rcs/api/consent/decision",
     "username": "psu4test",
     "userId": "4737f9f9-fa0a-4159-bc61-7da31542e624",
     "clientId": "71ca6faf-08a6-4db8-a70a-0a086900f606",

--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent-dev/mocks/international-standing-order-consent-details.js
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent-dev/mocks/international-standing-order-consent-details.js
@@ -1,7 +1,7 @@
 module.exports = {
   "type": "InternationalStandingOrderConsentDetails",
   "consentId": "PISOC_8f28f27e-5a19-4fa7-951d-9fd3ff5f24",
-  "decisionApiUri": "/rcs/api/consent/decision/",
+  "decisionApiUri": "/rcs/api/consent/decision",
   "username": "psu4test",
   "userId": "4737f9f9-fa0a-4159-bc61-7da31542e624",
   "clientId": "88ca3111-fa9f-4ff3-a61d-6cd9961606c5",

--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent-dev/mocks/vrp-payment-consent-details.js
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent-dev/mocks/vrp-payment-consent-details.js
@@ -1,7 +1,7 @@
 module.exports = {
   "type": "DomesticVrpPaymentConsentDetails",
   "consentId": "DVRP_9dd1fd32-0152-4250-a91f-462520d69b9",
-  "decisionApiUri": "/rcs/api/consent/decision/",
+  "decisionApiUri": "/rcs/api/consent/decision",
   "username": "psu4test",
   "userId": "4737f9f9-fa0a-4159-bc61-7da31542e624",
   "clientId": "c4bc928e-f316-4191-8616-a89fbc3677c8",

--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/funds-confirmation/funds-confirmation.component.spec.ts
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/pages/consent/funds-confirmation/funds-confirmation.component.spec.ts
@@ -24,7 +24,7 @@ describe('app:bank FundsConfirmationComponent', () => {
   const responseObject = {
     "type": "FundsConfirmationConsentDetails",
     "consentId": "FCC_67e60d61-2cd4-4e9c-a473-8680b8e7c309",
-    "decisionApiUri": "/rcs/api/consent/decision/",
+    "decisionApiUri": "/rcs/api/consent/decision",
     "username": "psu4test",
     "userId": "4737f9f9-fa0a-4159-bc61-7da31542e624",
     "clientId": "ce058417-bedc-444e-ba3d-fb793423ad27",

--- a/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/services/api.service.ts
+++ b/secure-api-gateway-ob-uk-ui-rcs/projects/rcs/src/app/services/api.service.ts
@@ -11,7 +11,7 @@ export class ApiService {
   }
 
   getConsentDetails(consentRequest: string) {
-    return this.http.post(`${this.configService.get('remoteConsentServer')}/rcs/api/consent/details/`, consentRequest, {
+    return this.http.post(`${this.configService.get('remoteConsentServer')}/rcs/api/consent/details`, consentRequest, {
       withCredentials: true,
       headers: new HttpHeaders({
         'Content-Type': 'application/jwt'

--- a/secure-api-gateway-ob-uk-ui-rcs/sample-details-json-files/account-response-details.json
+++ b/secure-api-gateway-ob-uk-ui-rcs/sample-details-json-files/account-response-details.json
@@ -1,6 +1,6 @@
 {
   "type": "AccountsConsentDetails",
-  "decisionApiUri": "/rcs/api/consent/decision/",
+  "decisionApiUri": "/rcs/api/consent/decision",
   "username": "psu",
   "userId": "b7b725b3-c471-4ef0-9704-732dd0cb2001",
   "logo": "https://forgerock.com",

--- a/secure-api-gateway-ob-uk-ui-rcs/sample-details-json-files/domestic-scheduled-payment-response-details.json
+++ b/secure-api-gateway-ob-uk-ui-rcs/sample-details-json-files/domestic-scheduled-payment-response-details.json
@@ -1,6 +1,6 @@
 {
   "type": "DomesticScheduledPaymentConsentDetails",
-  "decisionApiUri": "/rcs/api/consent/decision/",
+  "decisionApiUri": "/rcs/api/consent/decision",
   "username": "psu4test",
   "userId": "737742f2-01e4-4efa-a131-77e6526f98d2",
   "logo": "https://forgerock.com",

--- a/secure-api-gateway-ob-uk-ui-rcs/sample-details-json-files/vrp-response-details.json
+++ b/secure-api-gateway-ob-uk-ui-rcs/sample-details-json-files/vrp-response-details.json
@@ -43,5 +43,5 @@
     }
   },
   "intentType": "DOMESTIC_VRP_PAYMENT_CONSENT",
-  "decisionAPIUri": "/rcs/api/consent/decision/"
+  "decisionAPIUri": "/rcs/api/consent/decision"
 }


### PR DESCRIPTION
Spring Boot 3 is not mapping URIs with the trailing slashes to the controllers. The use of a trailing slash is incorrect and should be removed.

Issue: https://github.com/SecureApiGateway/secure-api-gateway-ob-uk-rcs/pull/1245