### PR TITLE
1307: Rename existing environments to [env]-ob

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -92,7 +92,7 @@ jobs:
         uses: codefresh-io/codefresh-pipeline-runner@master
         if: github.actor != 'dependabot[bot]'
         with:
-          args: '-v TAG=${{ env.PR_NUMBER }} -v ARGO_VALUES_PREFIX=remoteConsentServiceUserInterface -v SERVICE_NAME=remote-consent-ui -v ENVIRONMENT=${{ env.GITHUB_USER }} -v BRANCH=${{ github.head_ref }}'
+          args: '-v TAG=${{ env.PR_NUMBER }} -v ARGO_VALUES_PREFIX=remoteConsentServiceUserInterface -v SERVICE_NAME=remote-consent-ui -v ENVIRONMENT=${{ env.GITHUB_USER }}-ob -v BRANCH=${{ github.head_ref }}'
         env:
           PIPELINE_NAME: 'ForgeCloud/sbat-infra/dev-ob-service-build'
           CF_API_KEY: ${{ secrets.CF_API_KEY }}


### PR DESCRIPTION
Append environment name with -ob

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1307