### PR TITLE
1315: Remove unwanted config from dev-core

### DIFF
--- a/_infra/helm/securebanking-ui/readme.md
+++ b/_infra/helm/securebanking-ui/readme.md
@@ -87,12 +87,12 @@ spec:
             - name: IDENTITY_PLATFORM_FQDN
               valueFrom:
                 configMapKeyRef:
-                  name: deployment-config
+                  name: core-deployment-config
                   key: IDENTITY_PLATFORM_FQDN
             - name: IG_FQDN
               valueFrom:
                 configMapKeyRef:
-                  name: deployment-config
+                  name: core-deployment-config
                   key: IG_FQDN
           resources:
             limits:
@@ -109,8 +109,8 @@ These are the environment variables declared in the `deployment.yaml`;
 |-----|---------|-------------|--------|
 | PORT | 8080 | What port does the container use |deployment.containerPort |
 | TEMPLATE | forgerock | | deployment.template |
-| IDENTITY_PLATFORM_FQDN | | iam.forgerock.financial | Custom Domain created in Cloud Instance | deployment-config |
-| IG_FQDN | sapig.forgerock.financial | IG DNS to be used | deployment-config |
+| IDENTITY_PLATFORM_FQDN | | iam.forgerock.financial | Custom Domain created in Cloud Instance | core-deployment-config |
+| IG_FQDN | sapig.forgerock.financial | IG DNS to be used | core-deployment-config |
 
 
 ### Values

--- a/_infra/helm/securebanking-ui/templates/deployment.yaml
+++ b/_infra/helm/securebanking-ui/templates/deployment.yaml
@@ -41,12 +41,12 @@ spec:
             - name: IDENTITY_PLATFORM_FQDN
               valueFrom:
                 configMapKeyRef:
-                  name: deployment-config
+                  name: core-deployment-config
                   key: IDENTITY_PLATFORM_FQDN
             - name: IG_FQDN
               valueFrom:
                 configMapKeyRef:
-                  name: deployment-config
+                  name: core-deployment-config
                   key: IG_FQDN
           resources:
             {{- toYaml .Values.deployment.resources | nindent 12 }}


### PR DESCRIPTION
Rename deployment-config to be core-deployment-config & ob-deployment-config
Change openig-secrets-env to core-secrets & ob-secrets

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1315