### PR TITLE
1389: Use CI Repo for standardised steps in github workflows

### DIFF
--- a/.github/workflows/release-rcs.yml
+++ b/.github/workflows/release-rcs.yml
@@ -8,7 +8,7 @@ on:
         required: false
         type: string
       releaseVersion:
-        description: "The version to be Released (#.#.# | #.#.#-RC#)"
+        description: "The version to be Released (#.#.# | #.#.#-rc#)"
         required: true
         type: string
 jobs:

--- a/.github/workflows/release-rcs.yml
+++ b/.github/workflows/release-rcs.yml
@@ -8,7 +8,7 @@ on:
         required: false
         type: string
       releaseVersion:
-        description: "The version to be Released (#.#.#.#)"
+        description: "The version to be Released (#.#.# | #.#.#-RC#)"
         required: true
         type: string
 jobs:

--- a/.github/workflows/release-rcs.yml
+++ b/.github/workflows/release-rcs.yml
@@ -1,102 +1,23 @@
-name: caller_release_RCS_UI
-run-name: Create RCS_UI release '${{ inputs.release_version_number }}'
+name: Release - Build, Deploy & Create Release
+run-name: "${{ inputs.releaseVersion }}: Release - Build, Deploy & Create Release"
 on:
   workflow_dispatch:
     inputs:
-      notes:
-        description: "Release notes"
+      releaseNotes:
+        description: "Release Notes - Issues Included in Release"
         required: false
         type: string
-        default: ''
-      release_version_number:
-        description: "Provide release version number"
+      releaseVersion:
+        description: "The version to be Released (#.#.#.#)"
         required: true
         type: string
-env:
-  # Set the environment with secrets provided by the caller (secrets section)
-  GIT_AUTHOR_NAME: ${{ secrets.GIT_COMMIT_USERNAME_BOT }}
-  GIT_AUTHOR_EMAIL: ${{ secrets.GIT_COMMIT_AUTHOR_EMAIL_BOT }}
-  GIT_COMMITTER_NAME: ${{ secrets.GIT_COMMIT_USERNAME_BOT }}
-  GIT_COMMITTER_EMAIL: ${{ secrets.GIT_COMMIT_AUTHOR_EMAIL_BOT }}
-
 jobs:
-
-  release_prepare_no_maven: # prepare for a release in scm, creates the tag and release branch with the proper release versions
-    name: Call release prepare
-    uses: SecureApiGateway/secure-api-gateway-parent/.github/workflows/release-prepare-no-maven.yml@master
+  run_release-template:
+    name: Release - Build, Deploy & Create Release
+    uses: SecureApiGateway/secure-api-gateway-ci/.github/workflows/reusable-release.yml@main
+    secrets: inherit
     with:
-      release_version_number: ${{ inputs.release_version_number }}
-    secrets:
-      GIT_COMMIT_USERNAME_BOT: ${{ secrets.GIT_COMMIT_USERNAME_BOT }}
-      GIT_COMMIT_AUTHOR_EMAIL_BOT: ${{ secrets.GIT_COMMIT_AUTHOR_EMAIL_BOT }}
-      release_github_token: ${{ secrets.RELEASE_PAT }}
-
-  release_docker:
-    name: Call publish docker
-    needs: [ release_prepare_no_maven ]
-    uses: SecureApiGateway/secure-api-gateway-parent/.github/workflows/release-publish-docker.yml@master
-    with:
-      release_version_number: ${{ inputs.release_version_number }}
-      release_tag_ref: ${{ needs.release_prepare_no_maven.outputs.release_tag_ref }}
-      SERVICE_NAME: ui/rcs
-      with_maven: false
-      GAR_RELEASE_REPO: ${{ vars.GAR_RELEASE_REPO }}
-    secrets:
-      GCR_CREDENTIALS_JSON: ${{ secrets.DEV_GAR_KEY }}
-
-  release_helm:
-    name: Call publish helm
-    needs: [ release_prepare_no_maven ]
-    uses: SecureApiGateway/secure-api-gateway-parent/.github/workflows/release-publish-helm.yml@master
-    with:
-      release_version_number: ${{ inputs.release_version_number }}
-      release_tag_ref: ${{ needs.release_prepare_no_maven.outputs.release_tag_ref }}
-      root_helm_directory: "_infra/helm/securebanking-ui"
-    secrets:
-      FR_ARTIFACTORY_USER_ACCESS_TOKEN: ${{ secrets.FR_ARTIFACTORY_USER_ACCESS_TOKEN }}
-      FR_HELM_REPO: ${{ secrets.FR_HELM_REPO }}
-
-  update_version:
-    name: Update version for the next development iteration
-    needs: [ release_prepare_no_maven, release_docker, release_helm ]
-    runs-on: ubuntu-latest
-    steps:
-      # https://github.com/actions/checkout
-      - name: Checkout Parent Repo
-        uses: actions/checkout@v4
-
-      # https://github.com/crazy-max/ghaction-import-gpg
-      # https://httgp.com/signing-commits-in-github-actions/
-      # Prepare the environment to sign the commits
-      - name: Import GPG key
-        id: gpg
-        uses: crazy-max/ghaction-import-gpg@v5
-        with:
-          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY_BOT }}
-          passphrase: ${{ secrets.GPG_KEY_PASSPHRASE_BOT }}
-          git_user_signingkey: true
-          git_commit_gpgsign: true
-
-      - name: update version
-        id: update_version
-        working-directory: ./secure-api-gateway-ob-uk-ui-rcs
-        run: |
-          npm version patch --no-git-tag-version
-
-      - name: push changes
-        id: push_changes
-        run: |
-          git add secure-api-gateway-ob-uk-ui-rcs/package.json secure-api-gateway-ob-uk-ui-rcs/package-lock.json
-          git commit -m "Prepare for the next development iteration"
-          git push -f
-
-  release_publish:
-    name: Call publish release
-    needs: [ release_prepare_no_maven, release_docker, release_helm, update_version ]
-    uses: SecureApiGateway/secure-api-gateway-parent/.github/workflows/release-publish.yml@master
-    with:
-      release_version_number: ${{ inputs.release_version_number }}
-      release_tag_ref: ${{ needs.release_prepare_no_maven.outputs.release_tag_ref }}
-      release_notes: ${{ inputs.notes }}
-    secrets:
-      release_github_token: ${{ secrets.RELEASE_PAT }}
+      componentName: secure-api-gateway-ob-uk-ui
+      dockerTag: $(echo ${{ github.sha }} | cut -c1-7)
+      releaseNotes: ${{ inputs.releaseNotes }}
+      releaseVersion: ${{ inputs.releaseVersion }}

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ ifndef setlatest
 endif
 	if [ "${setlatest}" = "true" ]; then \
 		cd secure-api-gateway-ob-uk-ui-${service} && \
-		docker build -f projects/${service}/docker/Dockerfile -t ${repo}/securebanking/ui/${service}:${tag} -t ${repo}/securebanking/ui/${service}:latest. ; \
+		docker build -f projects/${service}/docker/Dockerfile -t ${repo}/securebanking/ui/${service}:${tag} -t ${repo}/securebanking/ui/${service}:latest . ; \
 		docker push ${repo}/securebanking/ui/${service} --all-tags; \
 	else \
 		cd secure-api-gateway-ob-uk-ui-${service} && \

--- a/Makefile
+++ b/Makefile
@@ -21,14 +21,16 @@ update_versions:
 # docker target
 docker:
 ifndef tag
-	$(warning No tag supplied, latest assumed. supply tag with make docker tag=x.x.x service=...)
-	$(eval tag=latest)
+	$(warning no tag supplied; latest assumed)
+	$(eval TAG=latest)
+else
+	$(eval TAG=$(shell echo $(tag) | tr A-Z a-z))
 endif
 ifndef setlatest
 	$(warning no setlatest true|false supplied; false assumed)
 	$(eval setlatest=false)
 endif
-	if [ "${setlatest}" = "true" ]; then \
+	@if [ "${setlatest}" = "true" ]; then \
 		cd secure-api-gateway-ob-uk-ui-${service} && \
 		docker build -f projects/${service}/docker/Dockerfile -t ${repo}/securebanking/ui/${service}:${tag} -t ${repo}/securebanking/ui/${service}:latest . ; \
 		docker push ${repo}/securebanking/ui/${service} --all-tags; \


### PR DESCRIPTION
Amend release workflow to use reusable CI repo workflow

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1389