### PR TITLE
1642: Create SAPIG 4.0.4

### DIFF
--- a/_infra/helm/securebanking-ui/Chart.yaml
+++ b/_infra/helm/securebanking-ui/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: remote-consent-service-user-interface
 description: RCS UI Helm chart for Kubernetes
 type: application
-version: 4.0.4
-appVersion: 4.0.4
+version: 4.0.5
+appVersion: 4.0.5


### PR DESCRIPTION
Bump helm version to `4.0.5`

Need to use 4.0.5 as 4.0.4 was released before discovering a [bug](https://github.com/SecureApiGateway/SecureApiGateway/issues/1647) in the UI

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1642